### PR TITLE
Support ForwardRef

### DIFF
--- a/src/cattr/__init__.py
+++ b/src/cattr/__init__.py
@@ -1,5 +1,6 @@
 from .converters import Converter, GenConverter, UnstructureStrategy
 from .gen import override
+from ._compat import resolve_types
 
 __all__ = (
     "global_converter",
@@ -11,6 +12,7 @@ __all__ = (
     "Converter",
     "GenConverter",
     "override",
+    "resolve_types",
 )
 
 

--- a/src/cattr/gen.py
+++ b/src/cattr/gen.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 import attr
-from attr import NOTHING, resolve_types
+from attr import NOTHING
 
 from ._compat import (
     adapted_fields,
@@ -24,6 +24,7 @@ from ._compat import (
     is_annotated,
     is_bare,
     is_generic,
+    resolve_types,
 )
 from ._generics import deep_copy_with
 
@@ -63,9 +64,8 @@ def make_dict_unstructure_fn(
     origin = get_origin(cl)
     attrs = adapted_fields(origin or cl)  # type: ignore
 
-    if any(isinstance(a.type, str) for a in attrs):
-        # PEP 563 annotations - need to be resolved.
-        resolve_types(cl)
+    # PEP 563 annotations and ForwardRefs - need to be resolved.
+    resolve_types(cl)
 
     mapping = {}
     if is_generic(cl):
@@ -245,9 +245,8 @@ def make_dict_structure_fn(
     attrs = adapted_fields(cl)
     is_dc = is_dataclass(cl)
 
-    if any(isinstance(a.type, str) for a in attrs):
-        # PEP 563 annotations - need to be resolved.
-        resolve_types(cl)
+    # PEP 563 annotations and ForwardRefs - need to be resolved.
+    resolve_types(cl)
 
     lines.append(f"def {fn_name}(o, *_):")
     lines.append("  res = {")

--- a/tests/module.py
+++ b/tests/module.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from typing import List, Tuple
+
+from attrs import define
+
+from cattr import resolve_types
+
+
+@dataclass
+class DClass:
+    ival: "IntType_1"
+    ilist: List["IntType_2"]
+
+
+@define
+class AClass:
+    ival: "IntType_3"
+    ilist: List["IntType_4"]
+
+
+@define
+class ModuleClass:
+    a: int
+
+
+IntType_1 = int
+IntType_2 = int
+IntType_3 = int
+IntType_4 = int
+
+RecursiveTypeAliasM = List[Tuple[ModuleClass, "RecursiveTypeAliasM"]]
+RecursiveTypeAliasM_1 = List[Tuple[ModuleClass, "RecursiveTypeAliasM_1"]]
+RecursiveTypeAliasM_2 = List[Tuple[ModuleClass, "RecursiveTypeAliasM_2"]]
+
+resolve_types(RecursiveTypeAliasM, globals(), locals())
+resolve_types(RecursiveTypeAliasM_1, globals(), locals())
+resolve_types(RecursiveTypeAliasM_2, globals(), locals())

--- a/tests/test_forwardref.py
+++ b/tests/test_forwardref.py
@@ -1,0 +1,296 @@
+"""Test un/structuring class graphs with ForwardRef."""
+from typing import List, Tuple, ForwardRef
+from dataclasses import dataclass
+
+import pytest
+
+from attr import define
+
+from cattr import Converter, GenConverter, resolve_types
+
+from . import module
+
+
+@define
+class A:
+    inner: List["A"]
+
+
+@dataclass
+class A_DC:
+    inner: List["A_DC"]
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_simple_recursive(converter_cls):
+    c = converter_cls()
+
+    orig = A([A([])])
+    unstructured = c.unstructure(orig, A)
+
+    assert unstructured == {"inner": [{"inner": []}]}
+
+    assert c.structure(unstructured, A) == orig
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_simple_recursive_dataclass(converter_cls):
+    c = converter_cls()
+
+    orig = A_DC([A_DC([])])
+    unstructured = c.unstructure(orig, A_DC)
+
+    assert unstructured == {"inner": [{"inner": []}]}
+
+    assert c.structure(unstructured, A_DC) == orig
+
+
+@define
+class A2:
+    val: "B_1"
+
+
+@dataclass
+class A2_DC:
+    val: "B_2"
+
+
+B_1 = int
+B_2 = int
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_simple_ref(converter_cls):
+    c = converter_cls()
+
+    orig = A2(1)
+    unstructured = c.unstructure(orig, A2)
+
+    assert unstructured == {"val": 1}
+
+    assert c.structure(unstructured, A2) == orig
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_simple_ref_dataclass(converter_cls):
+    c = converter_cls()
+
+    orig = A2_DC(1)
+    unstructured = c.unstructure(orig, A2_DC)
+
+    assert unstructured == {"val": 1}
+
+    assert c.structure(unstructured, A2_DC) == orig
+
+
+@define
+class A3:
+    val: List["B3_1"]
+
+
+@dataclass
+class A3_DC:
+    val: List["B3_2"]
+
+
+B3_1 = int
+B3_2 = int
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_nested_ref(converter_cls):
+    c = converter_cls()
+
+    orig = A3([1])
+    unstructured = c.unstructure(orig, A3)
+
+    assert unstructured == {"val": [1]}
+
+    assert c.structure(unstructured, A3) == orig
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_nested_ref_dataclass(converter_cls):
+    c = converter_cls()
+
+    orig = A3_DC([1])
+    unstructured = c.unstructure(orig, A3_DC)
+
+    assert unstructured == {"val": [1]}
+
+    assert c.structure(unstructured, A3_DC) == orig
+
+
+@define
+class AClassChild(module.AClass):
+    x: str
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_nested_ref_imported(converter_cls):
+    c = converter_cls()
+
+    orig = AClassChild(ival=1, ilist=[2, 3], x="4")
+    unstructured = c.unstructure(orig, AClassChild)
+
+    assert unstructured == {"ival": 1, "ilist": [2, 3], "x": "4"}
+
+    assert c.structure(unstructured, AClassChild) == orig
+
+
+@dataclass
+class DClassChild(module.DClass):
+    x: str
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_nested_ref_imported_dataclass(converter_cls):
+    c = converter_cls()
+
+    orig = DClassChild(ival=1, ilist=[2, 3], x="4")
+    unstructured = c.unstructure(orig, DClassChild)
+
+    assert unstructured == {"ival": 1, "ilist": [2, 3], "x": "4"}
+
+    assert c.structure(unstructured, DClassChild) == orig
+
+
+@define
+class Dummy:
+    a: int
+
+
+RecursiveTypeAlias_1 = List[Tuple[Dummy, "RecursiveTypeAlias_1"]]
+RecursiveTypeAlias_2 = List[Tuple[Dummy, "RecursiveTypeAlias_2"]]
+
+
+@define
+class ATest:
+    test: RecursiveTypeAlias_1
+
+
+@dataclass
+class DTest:
+    test: RecursiveTypeAlias_2
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_recursive_type_alias_manual_registration(converter_cls):
+    c = converter_cls()
+    c.register_structure_hook(
+        ForwardRef("RecursiveTypeAlias_1"),
+        lambda obj, _: c.structure(obj, RecursiveTypeAlias_1),
+    )
+    c.register_unstructure_hook(
+        ForwardRef("RecursiveTypeAlias_1"),
+        lambda obj: c.unstructure(obj, RecursiveTypeAlias_1),
+    )
+    c.register_structure_hook(
+        ForwardRef("RecursiveTypeAlias_2"),
+        lambda obj, _: c.structure(obj, RecursiveTypeAlias_2),
+    )
+    c.register_unstructure_hook(
+        ForwardRef("RecursiveTypeAlias_2"),
+        lambda obj: c.unstructure(obj, RecursiveTypeAlias_2),
+    )
+
+    orig = [(Dummy(1), [(Dummy(2), [(Dummy(3), [])])])]
+    unstructured = c.unstructure(orig, RecursiveTypeAlias_1)
+
+    assert unstructured == [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+
+    assert c.structure(unstructured, RecursiveTypeAlias_1) == orig
+
+    orig = ATest(test=[(Dummy(1), [(Dummy(2), [(Dummy(3), [])])])])
+    unstructured = c.unstructure(orig, ATest)
+
+    assert unstructured == {
+        "test": [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+    }
+
+    assert c.structure(unstructured, ATest) == orig
+
+    orig = DTest(test=[(Dummy(1), [(Dummy(2), [(Dummy(3), [])])])])
+    unstructured = c.unstructure(orig, DTest)
+
+    assert unstructured == {
+        "test": [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+    }
+
+    assert c.structure(unstructured, DTest) == orig
+
+
+RecursiveTypeAlias3 = List[Tuple[Dummy, "RecursiveTypeAlias3"]]
+
+resolve_types(RecursiveTypeAlias3, globals(), locals())
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_recursive_type_alias_cattr_resolution(converter_cls):
+    c = converter_cls()
+
+    orig = [(Dummy(1), [(Dummy(2), [(Dummy(3), [])])])]
+    unstructured = c.unstructure(orig, RecursiveTypeAlias3)
+
+    assert unstructured == [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+
+    assert c.structure(unstructured, RecursiveTypeAlias3) == orig
+
+
+@define
+class ATest4:
+    test: module.RecursiveTypeAliasM_1
+
+
+@dataclass
+class DTest4:
+    test: module.RecursiveTypeAliasM_2
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_recursive_type_alias_imported(converter_cls):
+    c = converter_cls()
+
+    orig = [
+        (
+            module.ModuleClass(1),
+            [(module.ModuleClass(2), [(module.ModuleClass(3), [])])],
+        )
+    ]
+    unstructured = c.unstructure(orig, module.RecursiveTypeAliasM)
+
+    assert unstructured == [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+
+    assert c.structure(unstructured, module.RecursiveTypeAliasM) == orig
+
+    orig = ATest4(
+        test=[
+            (
+                module.ModuleClass(1),
+                [(module.ModuleClass(2), [(module.ModuleClass(3), [])])],
+            )
+        ]
+    )
+    unstructured = c.unstructure(orig, ATest4)
+
+    assert unstructured == {
+        "test": [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+    }
+
+    assert c.structure(unstructured, ATest4) == orig
+
+    orig = DTest4(
+        test=[
+            (
+                module.ModuleClass(1),
+                [(module.ModuleClass(2), [(module.ModuleClass(3), [])])],
+            )
+        ]
+    )
+    unstructured = c.unstructure(orig, DTest4)
+
+    assert unstructured == {
+        "test": [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+    }
+
+    assert c.structure(unstructured, DTest4) == orig

--- a/tests/test_forwardref_563.py
+++ b/tests/test_forwardref_563.py
@@ -1,0 +1,268 @@
+"""Test un/structuring class graphs with ForwardRef."""
+# This file is almost same as test_forwardref.py but with
+# PEP 563 (delayed evaluation of annotations) enabled.
+# Even though with PEP 563 the explicit ForwardRefs
+# (with string quotes) would not always be needed, they
+# still can be used.
+from __future__ import annotations
+from typing import List, Tuple, ForwardRef
+from dataclasses import dataclass
+
+import pytest
+
+from attr import define
+
+from cattr import Converter, GenConverter, resolve_types
+
+from . import module
+
+
+@define
+class A2:
+    val: "B_1"
+
+
+@dataclass
+class A2_DC:
+    val: "B_2"
+
+
+B_1 = int
+B_2 = int
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_simple_ref(converter_cls):
+    c = converter_cls()
+
+    orig = A2(1)
+    unstructured = c.unstructure(orig, A2)
+
+    assert unstructured == {"val": 1}
+
+    assert c.structure(unstructured, A2) == orig
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_simple_ref_dataclass(converter_cls):
+    c = converter_cls()
+
+    orig = A2_DC(1)
+    unstructured = c.unstructure(orig, A2_DC)
+
+    assert unstructured == {"val": 1}
+
+    assert c.structure(unstructured, A2_DC) == orig
+
+
+@define
+class A3:
+    val: List["B3_1"]
+
+
+@dataclass
+class A3_DC:
+    val: List["B3_2"]
+
+
+B3_1 = int
+B3_2 = int
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_nested_ref(converter_cls):
+    c = converter_cls()
+
+    orig = A3([1])
+    unstructured = c.unstructure(orig, A3)
+
+    assert unstructured == {"val": [1]}
+
+    assert c.structure(unstructured, A3) == orig
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_nested_ref_dataclass(converter_cls):
+    c = converter_cls()
+
+    orig = A3_DC([1])
+    unstructured = c.unstructure(orig, A3_DC)
+
+    assert unstructured == {"val": [1]}
+
+    assert c.structure(unstructured, A3_DC) == orig
+
+
+@define
+class AClassChild(module.AClass):
+    x: str
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_nested_ref_imported(converter_cls):
+    c = converter_cls()
+
+    orig = AClassChild(ival=1, ilist=[2, 3], x="4")
+    unstructured = c.unstructure(orig, AClassChild)
+
+    assert unstructured == {"ival": 1, "ilist": [2, 3], "x": "4"}
+
+    assert c.structure(unstructured, AClassChild) == orig
+
+
+@dataclass
+class DClassChild(module.DClass):
+    x: str
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_nested_ref_imported_dataclass(converter_cls):
+    c = converter_cls()
+
+    orig = DClassChild(ival=1, ilist=[2, 3], x="4")
+    unstructured = c.unstructure(orig, DClassChild)
+
+    assert unstructured == {"ival": 1, "ilist": [2, 3], "x": "4"}
+
+    assert c.structure(unstructured, DClassChild) == orig
+
+
+@define
+class Dummy:
+    a: int
+
+
+RecursiveTypeAlias_1 = List[Tuple[Dummy, "RecursiveTypeAlias_1"]]
+RecursiveTypeAlias_2 = List[Tuple[Dummy, "RecursiveTypeAlias_2"]]
+
+
+@define
+class ATest:
+    test: RecursiveTypeAlias_1
+
+
+@dataclass
+class DTest:
+    test: RecursiveTypeAlias_2
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_recursive_type_alias_manual_registration(converter_cls):
+    c = converter_cls()
+    c.register_structure_hook(
+        ForwardRef("RecursiveTypeAlias_1"),
+        lambda obj, _: c.structure(obj, RecursiveTypeAlias_1),
+    )
+    c.register_unstructure_hook(
+        ForwardRef("RecursiveTypeAlias_1"),
+        lambda obj: c.unstructure(obj, RecursiveTypeAlias_1),
+    )
+    c.register_structure_hook(
+        ForwardRef("RecursiveTypeAlias_2"),
+        lambda obj, _: c.structure(obj, RecursiveTypeAlias_2),
+    )
+    c.register_unstructure_hook(
+        ForwardRef("RecursiveTypeAlias_2"),
+        lambda obj: c.unstructure(obj, RecursiveTypeAlias_2),
+    )
+
+    orig = [(Dummy(1), [(Dummy(2), [(Dummy(3), [])])])]
+    unstructured = c.unstructure(orig, RecursiveTypeAlias_1)
+
+    assert unstructured == [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+
+    assert c.structure(unstructured, RecursiveTypeAlias_1) == orig
+
+    orig = ATest(test=[(Dummy(1), [(Dummy(2), [(Dummy(3), [])])])])
+    unstructured = c.unstructure(orig, ATest)
+
+    assert unstructured == {
+        "test": [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+    }
+
+    assert c.structure(unstructured, ATest) == orig
+
+    orig = DTest(test=[(Dummy(1), [(Dummy(2), [(Dummy(3), [])])])])
+    unstructured = c.unstructure(orig, DTest)
+
+    assert unstructured == {
+        "test": [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+    }
+
+    assert c.structure(unstructured, DTest) == orig
+
+
+RecursiveTypeAlias3 = List[Tuple[Dummy, "RecursiveTypeAlias3"]]
+
+resolve_types(RecursiveTypeAlias3, globals(), locals())
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_recursive_type_alias_cattr_resolution(converter_cls):
+    c = converter_cls()
+
+    orig = [(Dummy(1), [(Dummy(2), [(Dummy(3), [])])])]
+    unstructured = c.unstructure(orig, RecursiveTypeAlias3)
+
+    assert unstructured == [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+
+    assert c.structure(unstructured, RecursiveTypeAlias3) == orig
+
+
+@define
+class ATest4:
+    test: module.RecursiveTypeAliasM_1
+
+
+@dataclass
+class DTest4:
+    test: module.RecursiveTypeAliasM_2
+
+
+@pytest.mark.parametrize("converter_cls", [GenConverter, Converter])
+def test_recursive_type_alias_imported(converter_cls):
+    c = converter_cls()
+
+    orig = [
+        (
+            module.ModuleClass(1),
+            [(module.ModuleClass(2), [(module.ModuleClass(3), [])])],
+        )
+    ]
+    unstructured = c.unstructure(orig, module.RecursiveTypeAliasM)
+
+    assert unstructured == [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+
+    assert c.structure(unstructured, module.RecursiveTypeAliasM) == orig
+
+    orig = ATest4(
+        test=[
+            (
+                module.ModuleClass(1),
+                [(module.ModuleClass(2), [(module.ModuleClass(3), [])])],
+            )
+        ]
+    )
+    unstructured = c.unstructure(orig, ATest4)
+
+    assert unstructured == {
+        "test": [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+    }
+
+    assert c.structure(unstructured, ATest4) == orig
+
+    orig = DTest4(
+        test=[
+            (
+                module.ModuleClass(1),
+                [(module.ModuleClass(2), [(module.ModuleClass(3), [])])],
+            )
+        ]
+    )
+    unstructured = c.unstructure(orig, DTest4)
+
+    assert unstructured == {
+        "test": [({"a": 1}, [({"a": 2}, [({"a": 3}, [])])])]
+    }
+
+    assert c.structure(unstructured, DTest4) == orig


### PR DESCRIPTION
This adds ForwardRef support to cattr (See #201). 

- ForwardRefs in classes 
   ```
   @dataclass
   class Test:
       x: List["XType"]

   XType = int
   ```
- Recursive classes
   ```
   @dataclass
   class Node:
       data: Dict
       left: Optional["Node"]
       right: Optional["Node"]
  ```

- Recursive type aliases. (Note: Even with [PEP 563](https://www.python.org/dev/peps/pep-0563/) we need ForwardRefs here)
   ```
   # Tree-like structure
   Node = Tuple[ Dict, Optional["Node"], Optional["Node"] ]

   class UserClass:
       some_tree_data: Node
   ```
- Recursive type aliases, across modules. (Needs explicit ForwardRef resolution, though. This is a Python limitation)
   ```
   # module.py
   Node = Tuple[ Dict, Optional["Node"], Optional["Node"] ]
   cattr.resolve_types(Node, globals(), locals())

   # main.py
   from module import Node
   class UserClass:
       some_tree_data: Node
   ```
- Manual registration (this worked before, but is still supported.) This PR also fixes #206)
   ```
   Node = Tuple[ Dict, Optional["Node"], Optional["Node"] ]

   c.register_structure_hook(
       ForwardRef("Node"), lambda obj, _: c.structure(obj, Node)
   )
   c.register_unstructure_hook(
       ForwardRef("Node"), lambda obj: c.unstructure(obj, Node)
   )
  ```


 
Specifically, the PR does

- Add hooks for ForwardRef (this equires ForwardRefs to be in resolved state, otherwise an error is generated)
- Ensure that ForwardRef are resolved for registered types, whenever it is possible to resolve them without context information. (Essentially this is done by a call `get_type_hints` on the type containing the ForwardRef).

   For this a new function `resolve_types` was added which is systematically used. It basically does the same thing as `attrs.resolve_types` but works for all types  (attrs classes, dataclasses and type aliases).
- ForwardRefs are now registered with direct dispatch and no longer singledispatch. This is to work around #206.
