### PR TITLE
Fix py37-38 structuring of mixed typing/regular generics

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ History
 * ``attrs`` and dataclass structuring is now ~25% faster.
 * Fix an issue structuring bare ``typing.List`` s on Pythons lower than 3.9.
   (`#209 <https://github.com/python-attrs/cattrs/issues/209>`_)
+* Fix structuring bare generics on Pythons lower than 3.9.
+  (`https://github.com/python-attrs/cattrs/issues/218`)
 
 1.10.0 (2022-01-04)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,8 +7,11 @@ History
 * ``attrs`` and dataclass structuring is now ~25% faster.
 * Fix an issue structuring bare ``typing.List`` s on Pythons lower than 3.9.
   (`#209 <https://github.com/python-attrs/cattrs/issues/209>`_)
-* Fix structuring bare generics on Pythons lower than 3.9.
+* Fix structuring of non-parametrized containers like ``list/dict/...`` on Pythons lower than 3.9.
   (`https://github.com/python-attrs/cattrs/issues/218`)
+* Fix structuring bare ``typing.Tuple`` on Pythons lower than 3.9.
+  (`https://github.com/python-attrs/cattrs/issues/218`)
+
 
 1.10.0 (2022-01-04)
 -------------------

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -166,6 +166,7 @@ if is_py37 or is_py38:
     bare_mapping_args = TypingMapping.__args__
     bare_dict_args = Dict.__args__
     bare_mutable_seq_args = TypingMutableSequence.__args__
+    bare_tuple_args = Tuple.__args__
 
     def is_bare(type):
         # Lower-cased generics in 3.7-8 do not have `__args__` attribute.
@@ -176,6 +177,7 @@ if is_py37 or is_py38:
             or args == bare_mapping_args
             or args == bare_dict_args
             or args == bare_mutable_seq_args
+            or args == bare_tuple_args
             or args is None
         )
 

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -168,13 +168,15 @@ if is_py37 or is_py38:
     bare_mutable_seq_args = TypingMutableSequence.__args__
 
     def is_bare(type):
-        args = type.__args__
+        # Lower-cased generics in 3.7-8 do not have `__args__` attribute.
+        args = getattr(type, "__args__", None)
         return (
             args == bare_list_args
             or args == bare_seq_args
             or args == bare_mapping_args
             or args == bare_dict_args
             or args == bare_mutable_seq_args
+            or args is None
         )
 
     def is_counter(type):

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -161,25 +161,18 @@ if is_py37 or is_py38:
             and issubclass(type.__origin__, TypingMapping)
         )
 
-    bare_list_args = List.__args__
-    bare_seq_args = TypingSequence.__args__
-    bare_mapping_args = TypingMapping.__args__
-    bare_dict_args = Dict.__args__
-    bare_mutable_seq_args = TypingMutableSequence.__args__
-    bare_tuple_args = Tuple.__args__
+    bare_generic_args = {
+        List.__args__,
+        TypingSequence.__args__,
+        TypingMapping.__args__,
+        Dict.__args__,
+        TypingMutableSequence.__args__,
+        Tuple.__args__,
+        None,  # non-parametrized containers do not have `__args__ attribute in py3.7-8
+    }
 
     def is_bare(type):
-        # Lower-cased generics in 3.7-8 do not have `__args__` attribute.
-        args = getattr(type, "__args__", None)
-        return (
-            args == bare_list_args
-            or args == bare_seq_args
-            or args == bare_mapping_args
-            or args == bare_dict_args
-            or args == bare_mutable_seq_args
-            or args == bare_tuple_args
-            or args is None
-        )
+        return getattr(type, "__args__", None) in bare_generic_args
 
     def is_counter(type):
         return (

--- a/src/cattrs/gen.py
+++ b/src/cattrs/gen.py
@@ -412,8 +412,10 @@ def make_iterable_unstructure_fn(cl: Any, converter, unstructure_to=None):
 
     fn_name = "unstructure_iterable"
 
-    # Let's try fishing out the type args.
-    if getattr(cl, "__args__", None) is not None:
+    # Let's try fishing out the type args
+    # Unspecified tuples have `__args__` as empty tuples, so guard
+    # against IndexError.
+    if getattr(cl, "__args__", None) not in (None, ()):
         type_arg = cl.__args__[0]
         # We don't know how to handle the TypeVar on this level,
         # so we skip doing the dispatch here.


### PR DESCRIPTION
Fixes #218

(EDIT 3.2.) I added tests describing the following behaviours:

* attribute annotated by a bare lower-case generic - `dict`, `frozenset`, `list`, `set`, `tuple`
* attribute annotated by a `typing.` upper-case generic with 1 type parameter, which can itself be a lower-case generic - this excludes sets and tuple
* attribute annotated by `typing.Tuple` with variadic lower-case generics


Cheers,
Libor