### PR TITLE
Fix  __parameters__ access in gen._generate_mapping

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,9 @@ History
 * Fix structuring bare ``typing.Tuple`` on Pythons lower than 3.9.
   (`#218 https://github.com/python-attrs/cattrs/issues/218`_)
 
+* Fix a wrong ``AttributeError`` of an missing ``__parameters__`` attribute. This could happen 
+  when inheriting certain generic classes – for example ``typing.*`` classes are affected. 
+  (`#217 <https://github.com/python-attrs/cattrs/issues/217>`_)
 
 1.10.0 (2022-01-04)
 -------------------

--- a/src/cattrs/gen.py
+++ b/src/cattrs/gen.py
@@ -204,7 +204,17 @@ def _generate_mapping(
     cl: Type, old_mapping: Dict[str, type]
 ) -> Dict[str, type]:
     mapping = {}
-    for p, t in zip(get_origin(cl).__parameters__, get_args(cl)):
+
+    # To handle the cases where classes in the typing module are using
+    # the GenericAlias structure but aren’t a Generic and hence
+    # end up in this function but do not have an `__parameters__`
+    # attribute. These classes are interface types, for example
+    # `typing.Hashable`.
+    parameters = getattr(get_origin(cl), "__parameters__", None)
+    if parameters is None:
+        return old_mapping
+
+    for p, t in zip(parameters, get_args(cl)):
         if isinstance(t, TypeVar):
             continue
         mapping[p.__name__] = t


### PR DESCRIPTION
There are Generic types in the typing modules
from which you can inherit in your own classes
which do not have an __parameters__ attribute,
such classes are now ignored making
gen._generate_mapping effectively a no-op
in case the class do not have an __parameters__
attribute.

As https://github.com/ilevkivskyi/typing_inspect/blob/8f6aa2075ba448ab322def454137e7c59b9b302d/typing_inspect.py#L405
is showing there are also cases where __parameters__
could be None, so I test for both cases, that it
is None or that it does not exist.

See Also:
https://github.com/python-attrs/cattrs/issues/217