### PR TITLE
Fix issue links in HISTORY

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,9 +8,9 @@ History
 * Fix an issue structuring bare ``typing.List`` s on Pythons lower than 3.9.
   (`#209 <https://github.com/python-attrs/cattrs/issues/209>`_)
 * Fix structuring of non-parametrized containers like ``list/dict/...`` on Pythons lower than 3.9.
-  (`#218 https://github.com/python-attrs/cattrs/issues/218`_)
+  (`#218 <https://github.com/python-attrs/cattrs/issues/218>`_)
 * Fix structuring bare ``typing.Tuple`` on Pythons lower than 3.9.
-  (`#218 https://github.com/python-attrs/cattrs/issues/218`_)
+  (`#218 <https://github.com/python-attrs/cattrs/issues/218>`_)
 
 
 1.10.0 (2022-01-04)


### PR DESCRIPTION
Sorry, I messed up the links to issues resolved - they display incorrectly and look like in the screenshot below:

![Screenshot 2022-02-05 at 11-10-27 python-attrs cattrs Complex custom class converters for attrs ](https://user-images.githubusercontent.com/38978799/152639655-1f588d1c-be6f-49a4-bbc1-8a4aa9cce61a.png)

