### PR TITLE
For `forbid_extra_keys` raise custom `ForbiddenExtraKeyError`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,7 +18,8 @@ History
   (`#231 <https://github.com/python-attrs/cattrs/pull/231>`_)
 * Fix unstructuring all tuples - unannotated, variable-length, homogenous and heterogenous - to `list`.
   (`#226 <https://github.com/python-attrs/cattrs/issues/226>`_)
-
+* For ``forbid_extra_keys`` raise custom ``ForbiddenExtraKeyError`` instead of generic ``Exception``.
+  (`#255 <https://github.com/python-attrs/cattrs/pull/225>`_)
 
 1.10.0 (2022-01-04)
 -------------------

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -108,7 +108,7 @@ creating structure hooks with ``make_dict_structure_fn``.
     >>> c.structure({"nummber": 2}, TestClass)
     Traceback (most recent call last):
     ...
-    Exception: Extra fields in constructor for TestClass: nummber
+    ForbiddenExtraKeyError: Extra fields in constructor for TestClass: nummber
     >>> hook = make_dict_structure_fn(TestClass, c, _cattrs_forbid_extra_keys=False)
     >>> c.register_structure_hook(TestClass, hook)
     >>> c.structure({"nummber": 2}, TestClass)

--- a/docs/structuring.rst
+++ b/docs/structuring.rst
@@ -473,7 +473,7 @@ Here's a small example showing how to use factory hooks to apply the `forbid_ext
     >>> c.structure({"an_int": 1, "else": 2}, E)
     Traceback (most recent call last):
     ...
-    Exception: Extra fields in constructor for E: else
+    ForbiddenExtraKeyError: Extra fields in constructor for E: else
 
 
 A complex use case for hook factories is described over at :ref:`Using factory hooks`.

--- a/src/cattrs/errors.py
+++ b/src/cattrs/errors.py
@@ -33,3 +33,7 @@ class ClassValidationError(BaseValidationError):
     """Raised when validating a class if any attributes are invalid."""
 
     pass
+
+
+class ForbiddenExtraKeyError(Exception):
+    """Raised when `forbid_extra_keys` is activated and such an extra key is detected during structuring."""

--- a/src/cattrs/errors.py
+++ b/src/cattrs/errors.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Optional, Set, Type
 
 from cattr._compat import ExceptionGroup
 
@@ -35,5 +35,23 @@ class ClassValidationError(BaseValidationError):
     pass
 
 
-class ForbiddenExtraKeyError(Exception):
-    """Raised when `forbid_extra_keys` is activated and such an extra key is detected during structuring."""
+class ForbiddenExtraKeysError(Exception):
+    """Raised when `forbid_extra_keys` is activated and such extra keys are detected during structuring.
+
+    The attribute `extra_fields` is a sequence of those extra keys, which were the cause of this error,
+    and `cl` is the class which was structured with those extra keys.
+    """
+
+    def __init__(
+        self, message: Optional[str], cl: Type, extra_fields: Set[str]
+    ) -> None:
+        self.cl = cl
+        self.extra_fields = extra_fields
+
+        msg = (
+            message
+            if message
+            else f"Extra fields in constructor for {cl.__name__}: {', '.join(extra_fields)}"
+        )
+
+        super().__init__(msg)

--- a/src/cattrs/gen.py
+++ b/src/cattrs/gen.py
@@ -452,7 +452,7 @@ def make_dict_structure_fn(
     if _cattrs_forbid_extra_keys:
         globs["__c_a"] = allowed_fields
         globs["__c_feke"] = ForbiddenExtraKeysError
-        post_lines += [
+        lines += [
             "  unknown_fields = set(o.keys()) - __c_a",
             "  if unknown_fields:",
             "    raise __c_feke('', __cl, unknown_fields)",

--- a/src/cattrs/gen.py
+++ b/src/cattrs/gen.py
@@ -447,10 +447,11 @@ def make_dict_structure_fn(
 
     if _cattrs_forbid_extra_keys:
         globs["__c_a"] = allowed_fields
+        globs["ForbiddenExtraKeyError"] = ForbiddenExtraKeyError
         post_lines += [
             "  unknown_fields = set(o.keys()) - __c_a",
             "  if unknown_fields:",
-            "    raise Exception(",
+            "    raise ForbiddenExtraKeyError(",
             f"      'Extra fields in constructor for {cl_name}: ' + ', '.join(unknown_fields)"
             "    )",
         ]

--- a/src/cattrs/gen.py
+++ b/src/cattrs/gen.py
@@ -17,7 +17,11 @@ from cattr._compat import (
     is_generic,
 )
 from cattr._generics import deep_copy_with
-from cattrs.errors import ClassValidationError, IterableValidationError
+from cattrs.errors import (
+    ClassValidationError,
+    ForbiddenExtraKeysError,
+    IterableValidationError,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from cattr.converters import Converter
@@ -447,13 +451,11 @@ def make_dict_structure_fn(
 
     if _cattrs_forbid_extra_keys:
         globs["__c_a"] = allowed_fields
-        globs["ForbiddenExtraKeyError"] = ForbiddenExtraKeyError
+        globs["__c_feke"] = ForbiddenExtraKeysError
         post_lines += [
             "  unknown_fields = set(o.keys()) - __c_a",
             "  if unknown_fields:",
-            "    raise ForbiddenExtraKeyError(",
-            f"      'Extra fields in constructor for {cl_name}: ' + ', '.join(unknown_fields)"
-            "    )",
+            "    raise __c_feke('', __cl, unknown_fields)",
         ]
 
     # At the end, we create the function header.

--- a/tests/metadata/test_genconverter.py
+++ b/tests/metadata/test_genconverter.py
@@ -19,6 +19,7 @@ from hypothesis.strategies import booleans, lists, sampled_from
 from cattr import GenConverter as Converter
 from cattr import UnstructureStrategy
 from cattr._compat import is_py39_plus, is_py310_plus
+from cattrs.errors import ForbiddenExtraKeyError
 from cattr.gen import make_dict_structure_fn, override
 
 from . import (
@@ -87,7 +88,7 @@ def test_forbid_extra_keys(cls_and_vals):
     while bad_key in unstructured:
         bad_key += "A"
     unstructured[bad_key] = 1
-    with pytest.raises(Exception):
+    with pytest.raises(ForbiddenExtraKeyError):
         converter.structure(unstructured, cl)
 
 
@@ -102,7 +103,7 @@ def test_forbid_extra_keys_defaults(attr_and_vals):
     inst = cl()
     unstructured = converter.unstructure(inst)
     unstructured["aa"] = unstructured.pop("a")
-    with pytest.raises(Exception):
+    with pytest.raises(ForbiddenExtraKeyError):
         converter.structure(unstructured, cl)
 
 
@@ -122,7 +123,7 @@ def test_forbid_extra_keys_nested_override():
     converter.structure(unstructured, A)
     # if we break it in the subclass, we need it to raise
     unstructured["c"]["aa"] = 5
-    with pytest.raises(Exception):
+    with pytest.raises(ForbiddenExtraKeyError):
         converter.structure(unstructured, A)
     # we can "fix" that by disabling forbid_extra_keys on the subclass
     hook = make_dict_structure_fn(C, converter, _cattrs_forbid_extra_keys=False)
@@ -130,7 +131,7 @@ def test_forbid_extra_keys_nested_override():
     converter.structure(unstructured, A)
     # but we should still raise at the top level
     unstructured["b"] = 6
-    with pytest.raises(Exception):
+    with pytest.raises(ForbiddenExtraKeyError):
         converter.structure(unstructured, A)
 
 

--- a/tests/test_gen_dict.py
+++ b/tests/test_gen_dict.py
@@ -7,6 +7,7 @@ from hypothesis.strategies._internal.core import data, sampled_from
 
 from cattr._compat import adapted_fields, fields
 from cattrs import Converter
+from cattrs.errors import ForbiddenExtraKeysError
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
 
 from . import nested_classes, simple_classes
@@ -226,7 +227,7 @@ def test_renaming_forbid_extra_keys():
 
     assert new_inst == A(1, "str")
 
-    with pytest.raises(Exception):
+    with pytest.raises(ForbiddenExtraKeysError):
         converter.structure({"b": 1, "c": "str"}, A)
 
 


### PR DESCRIPTION
When `forbid_extra_keys` is actived, I would like to be able to try-except that specific Problem (here `ForbiddenExtraKeyError`) instead of any `Exception`.

The unit tests also gain a little more percition through that change.