### PR TITLE
Fix inconsistent `tuple/typing.Tuple` unstructuring

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,8 @@ History
 * Fix a wrong ``AttributeError`` of an missing ``__parameters__`` attribute. This could happen 
   when inheriting certain generic classes – for example ``typing.*`` classes are affected. 
   (`#217 <https://github.com/python-attrs/cattrs/issues/217>`_)
+* Fix unstructuring all tuples - unannotated, variable-length, homogenous and heterogenous - to `list`.
+  (`#226 <https://github.com/python-attrs/cattrs/issues/226>`_)
 
 1.10.0 (2022-01-04)
 -------------------

--- a/src/cattr/_compat.py
+++ b/src/cattr/_compat.py
@@ -277,6 +277,7 @@ else:
                 TypingSequence,
                 TypingMutableSequence,
                 AbcMutableSequence,
+                Tuple,
                 tuple,
             )
             or (

--- a/src/cattr/converters.py
+++ b/src/cattr/converters.py
@@ -760,7 +760,7 @@ class GenConverter(Converter):
 
     def gen_unstructure_hetero_tuple(self, cl: Any, unstructure_to=None):
         unstructure_to = self._unstruct_collection_overrides.get(
-            get_origin(cl) or cl, unstructure_to or tuple
+            get_origin(cl) or cl, unstructure_to or list
         )
         h = make_hetero_tuple_unstructure_fn(cl, self, unstructure_to=unstructure_to)
         self._unstructure_func.register_cls_list([(cl, h)], direct=True)


### PR DESCRIPTION
Fixes #226
Fixes #214

Now, all tuples are unstructured to `list` by default.

<strike>Needs a changelog entry and</strike> we are ready to go!