### PR TITLE
fix test failure on Windows

### DIFF
--- a/tests/test_preconf.py
+++ b/tests/test_preconf.py
@@ -103,7 +103,7 @@ def everythings(
         )
     )
     dts = datetimes(
-        min_value=datetime(1904, 1, 1),
+        min_value=datetime(1970, 1, 1),
         max_value=datetime(2038, 1, 1),
         timezones=just(timezone.utc),
     )


### PR DESCRIPTION
On Windows, `datetime.fromtimestamp` only seems to support positive values, cause test_msgpack in test_preconf to fail with OSError.