### PR TITLE
Fix handling of Enums in Literal types

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,10 +11,11 @@ History
   (`#218 <https://github.com/python-attrs/cattrs/issues/218>`_)
 * Fix structuring bare ``typing.Tuple`` on Pythons lower than 3.9.
   (`#218 <https://github.com/python-attrs/cattrs/issues/218>`_)
-
 * Fix a wrong ``AttributeError`` of an missing ``__parameters__`` attribute. This could happen 
   when inheriting certain generic classes – for example ``typing.*`` classes are affected. 
   (`#217 <https://github.com/python-attrs/cattrs/issues/217>`_)
+* Fix structuring of ``enum.Enum`` instances in ``typing.Literal`` types.
+  (`#231 <https://github.com/python-attrs/cattrs/pull/231>`_)
 
 1.10.0 (2022-01-04)
 -------------------


### PR DESCRIPTION
Literal allows Enum values to be specified, however, the Literal check did not account for that:

```py
import cattrs, enum
from typing import Literal

class A(enum.Enum):
    BLA = 1
    BLAA = 2

@attrs.define
class Works:
    a: A

@attrs.define
class Broken:
    a: Literal[A.BLA]

print(cattrs.structure({"a": 1}, Works))   # Works(a=<A.BLA: 1>)
print(cattrs.structure({"a": 1}, Broken))  # Exception: 1 not in literal typing.Literal[<A.BLA: 1>]
```

(This would work if A would also inherit from int.)

It makes sense that if cattrs already accepts 1 as a valid enum value, the Literal check should go by value as well.

This PR fixes this bug, ~~and also slightly modifies an existing test to make sure that `Literal[1, Literal[2]]` is handled like `Literal[1, 2]`.~~ *(Edit: the last part is not correctly supported by cattrs yet, so the test was reversed in a later version of this PR)*