### PR TITLE
Uncap Python dependency

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ History
 * Fix propagating the `detailed_validation` flag to mapping and counter structuring generators.
 * Fix ``typing.Set`` applying too broadly when used with the ``GenConverter.unstruct_collection_overrides`` parameter on Python versions below 3.9. Switch to ``typing.AbstractSet`` on those versions to restore the old behavior.
   (`#264 <https://github.com/python-attrs/cattrs/issues/264>`_)
+* Uncap the minimum required Python version, to avoid problems detailed in https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special (`#275 <https://github.com/python-attrs/cattrs/issues/275>`_)
 
 22.1.0 (2022-04-03)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ packages = [
 readme = "README.rst"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">= 3.7"
 attrs = ">= 20"
 typing_extensions = { version = "*", python = "< 3.8" }
 exceptiongroup = { version = "*", python = "< 3.11" }


### PR DESCRIPTION
See https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special for the rationale.

Closes https://github.com/python-attrs/cattrs/issues/275.