### PR TITLE
Fix: GenConverter syntax errors with certain types

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,7 @@ History
 * Fix `Converter.register_structure_hook_factory` and `cattrs.gen.make_dict_unstructure_fn` type annotations.
   (`#281 <https://github.com/python-attrs/cattrs/issues/281>`_)
 * Expose all error classes in the `cattr.errors` namespace. Note that it is deprecated, just use `cattrs.errors`. (`#252 <https://github.com/python-attrs/cattrs/issues/252>`_)
+* Fix generating structuring functions for types with quotes in the name. (`#291 <https://github.com/python-attrs/cattrs/issues/291>`_ `#277 <https://github.com/python-attrs/cattrs/issues/277>`_)
 
 22.1.0 (2022-04-03)
 -------------------

--- a/src/cattrs/gen.py
+++ b/src/cattrs/gen.py
@@ -340,7 +340,7 @@ def make_dict_structure_fn(
             lines.append(f"{i}except Exception as e:")
             i = f"{i}  "
             lines.append(
-                f"{i}e.__note__ = 'Structuring class {cl.__qualname__} @ attribute {an}'"
+                f"{i}e.__note__ = 'Structuring class ' + {cl.__qualname__!r} + ' @ attribute', {an}"
             )
             lines.append(f"{i}errors.append(e)")
 
@@ -352,7 +352,7 @@ def make_dict_structure_fn(
             ]
 
         post_lines.append(
-            f"  if errors: raise __c_cve('While structuring {cl.__name__}', errors, __cl)"
+            f"  if errors: raise __c_cve('While structuring ' + {cl.__name__!r}, errors, __cl)"
         )
         instantiation_lines = (
             ["  try:"]
@@ -360,7 +360,7 @@ def make_dict_structure_fn(
             + [f"      {line}" for line in invocation_lines]
             + ["    )"]
             + [
-                f"  except Exception as exc: raise __c_cve('While structuring {cl.__name__}', [exc], __cl)"
+                f"  except Exception as exc: raise __c_cve('While structuring ' + {cl.__name__!r}, [exc], __cl)"
             ]
         )
     else:
@@ -717,7 +717,7 @@ def make_mapping_structure_fn(
             lines.append("      errors.append(e)")
             lines.append("  if errors:")
             lines.append(
-                f"    raise IterableValidationError('While structuring {cl!r}', errors, __cattr_mapping_cl)"
+                f"    raise IterableValidationError('While structuring ' + {repr(cl)!r}, errors, __cattr_mapping_cl)"
             )
         else:
             lines.append(f"  res = {{{k_s}: {v_s} for k, v in mapping.items()}}")

--- a/src/cattrs/gen.py
+++ b/src/cattrs/gen.py
@@ -340,7 +340,7 @@ def make_dict_structure_fn(
             lines.append(f"{i}except Exception as e:")
             i = f"{i}  "
             lines.append(
-                f"{i}e.__note__ = 'Structuring class ' + {cl.__qualname__!r} + ' @ attribute', {an}"
+                f"{i}e.__note__ = 'Structuring class ' + {cl.__qualname__!r} + ' @ attribute {an}'"
             )
             lines.append(f"{i}errors.append(e)")
 

--- a/tests/test_gen_dict.py
+++ b/tests/test_gen_dict.py
@@ -292,15 +292,15 @@ def test_omitting_structure(extended_validation: bool):
 @pytest.mark.skipif(not is_py39_plus, reason="literals and annotated are 3.9+")
 def test_type_names_with_quotes():
     """Types with quote characters in their reprs should work."""
-    from typing import Annotated, Literal
+    from typing import Annotated, Literal, Union
 
     converter = Converter()
 
     assert converter.structure({1: 1}, Dict[Annotated[int, "'"], int]) == {1: 1}
 
     converter.register_structure_hook_func(
-        lambda t: t is Literal["a", 2, 3] | Literal[4], lambda v, _: v
+        lambda t: t is Union[Literal["a", 2, 3], Literal[4]], lambda v, _: v
     )
     assert converter.structure(
-        {2: "a"}, Dict[Literal["a", 2, 3] | Literal[4], str]
+        {2: "a"}, Dict[Union[Literal["a", 2, 3], Literal[4]], str]
     ) == {2: "a"}

--- a/tests/test_gen_dict.py
+++ b/tests/test_gen_dict.py
@@ -8,7 +8,7 @@ from hypothesis import assume, given
 from hypothesis.strategies import data, just, one_of, sampled_from
 
 from cattrs import BaseConverter, Converter
-from cattrs._compat import adapted_fields, fields
+from cattrs._compat import adapted_fields, fields, is_py39_plus
 from cattrs.errors import ClassValidationError, ForbiddenExtraKeysError
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
 
@@ -289,6 +289,7 @@ def test_omitting_structure(extended_validation: bool):
     assert not hasattr(structured, "b")
 
 
+@pytest.mark.skipif(not is_py39_plus, reason="literals and annotated are 3.9+")
 def test_type_names_with_quotes():
     """Types with quote characters in their reprs should work."""
 

--- a/tests/test_gen_dict.py
+++ b/tests/test_gen_dict.py
@@ -1,5 +1,5 @@
 """Tests for generated dict functions."""
-from typing import Type
+from typing import Annotated, Dict, Literal, Type
 
 import pytest
 from attr import Factory, define, field
@@ -287,3 +287,18 @@ def test_omitting_structure(extended_validation: bool):
     assert structured.a == 1
     assert structured.c == 1
     assert not hasattr(structured, "b")
+
+
+def test_type_names_with_quotes():
+    """Types with quote characters in their reprs should work."""
+
+    converter = Converter()
+
+    assert converter.structure({1: 1}, Dict[Annotated[int, "'"], int]) == {1: 1}
+
+    converter.register_structure_hook_func(
+        lambda t: t is Literal["a", 2, 3] | Literal[4], lambda v, _: v
+    )
+    assert converter.structure(
+        {2: "a"}, Dict[Literal["a", 2, 3] | Literal[4], str]
+    ) == {2: "a"}

--- a/tests/test_gen_dict.py
+++ b/tests/test_gen_dict.py
@@ -1,5 +1,5 @@
 """Tests for generated dict functions."""
-from typing import Annotated, Dict, Literal, Type
+from typing import Dict, Type
 
 import pytest
 from attr import Factory, define, field
@@ -292,6 +292,7 @@ def test_omitting_structure(extended_validation: bool):
 @pytest.mark.skipif(not is_py39_plus, reason="literals and annotated are 3.9+")
 def test_type_names_with_quotes():
     """Types with quote characters in their reprs should work."""
+    from typing import Annotated, Literal
 
     converter = Converter()
 


### PR DESCRIPTION
Certain uses of `typing.Literal` or `typing.Annotated` cause syntax errors in generated code. (Related: https://github.com/python-attrs/cattrs/issues/277)

In the case of annotated types (from 3.7 typing_extensions), I get the following syntax error:
```
    eval(compile(script, "", "exec"), globs)
E     File "<string>", line 17
E       raise IterableValidationError('While structuring typing.Dict[typing_extensions.Annotated[str, <class 'housecats.annotations.sanitization.PIIAnnotation'>], vnxpy.jobs.types.leaf.AssigneeRemoval]', errors, __cattr_mapping_cl)
E                                                                                                                     ^
E   SyntaxError: invalid syntax
```

As mentioned in #277 by @Tinche; we _could_ escape quotes manually but using `repr()` on the string is much easier (it returns a string literal)

I tried to write some minimal tests for this but was having some unrelated issues with Poetry/tox that I don't have bandwidth to figure out at the moment. I can however confirm that these changes work when modifying cattrs 22.1.0 in my project's site_packages.