### PR TITLE
Fix imprecise dependency on poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,5 +69,5 @@ source = [
 ]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.1.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Related to #202 and https://github.com/python-poetry/poetry/issues/4938 - looks like poetry 1.2.0 depends on poetry-core 1.1.0, so I assume the 'groups' feature is present in poetry-core 1.1.0 and that version would be a good one to use.