### PR TITLE
Fix a misspell in documentation for CBOR converter

### DIFF
--- a/docs/preconf.md
+++ b/docs/preconf.md
@@ -88,7 +88,7 @@ Tuples are serialized as lists.
 Use keyword argument `datetime_as_timestamp=True` to encode as UNIX timestamp integer/float (CBOR Tag 1)
 **note:** this replaces timezone information as UTC.
 
-Use keyword arguemnt `canonical=True` for efficient encoding to the smallest binary output.
+Use keyword argument `canonical=True` for efficient encoding to the smallest binary output.
 
 Floats can be forced to smaller output by casting to lower-precision formats by casting to `numpy` floats (and back to Python floats).
 Example: `float(np.float32(value))` or `float(np.float16(value))`


### PR DESCRIPTION
This PR just fixes a misspell in the documentation for  converter preconfigured for CBOR - "arguemnt" -> "argument"