### PR TITLE
Fix minor typo

### DIFF
--- a/docs/structuring.md
+++ b/docs/structuring.md
@@ -245,7 +245,7 @@ The tuple conversion is composable with all other converters.
 ### Unions
 
 Unions of `NoneType` and a single other type are supported (also known as
-`Optional` s). All other unions a require a disambiguation function.
+`Optional` s). All other unions require a disambiguation function.
 
 #### Automatic Disambiguation
 


### PR DESCRIPTION
```diff
- All other unions a require a disambiguation function.
+ All other unions require a disambiguation function.
```