### PR TITLE
Add unstructuring and structuring support for `deque` in standard lib

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,8 @@
   ([#350](https://github.com/python-attrs/cattrs/issues/350) [#353](https://github.com/python-attrs/cattrs/pull/353))
 - Subclasses structuring and unstructuring is now supported via a custom `include_subclasses` strategy.
   ([#312](https://github.com/python-attrs/cattrs/pull/312))
+- Add unstructuring and structuring support to `deque` in standard lib.
+  ([#355](https://github.com/python-attrs/cattrs/issues/355))
 
 ## 22.2.0 (2022-10-03)
 

--- a/docs/structuring.md
+++ b/docs/structuring.md
@@ -154,8 +154,9 @@ to deques are:
 - `Deque[T]`
 - `deque[T]`
 
-In all cases, a new unbounded deque (`maxlen=None`) will be returned, so this operation can be used to
+In all cases, a new **unbounded** deque (`maxlen=None`) will be returned, so this operation can be used to
 copy an iterable into a deque.
+If you want to convert into bounded `deque`, registering a custom structuring hook is a good approach.
 
 ```{doctest}
 >>> cattrs.structure((1, 2, 3), deque[int])
@@ -167,6 +168,9 @@ These generic types are composable with all other converters.
 ```{doctest}
 >>> cattrs.structure((1, None, 3), deque[Optional[str]])
 ['1', None, '3']
+```
+
+```{versionadded} 23.1.0
 ```
 
 ### Sets and Frozensets

--- a/docs/structuring.md
+++ b/docs/structuring.md
@@ -146,6 +146,29 @@ These generic types are composable with all other converters.
 ['1', None, '3']
 ```
 
+### Deques
+
+Deques can be produced from any iterable object. Types converting
+to deques are:
+
+- `Deque[T]`
+- `deque[T]`
+
+In all cases, a new unbounded deque (`maxlen=None`) will be returned, so this operation can be used to
+copy an iterable into a deque.
+
+```{doctest}
+>>> cattrs.structure((1, 2, 3), deque[int])
+[1, 2, 3]
+```
+
+These generic types are composable with all other converters.
+
+```{doctest}
+>>> cattrs.structure((1, None, 3), deque[Optional[str]])
+['1', None, '3']
+```
+
 ### Sets and Frozensets
 
 Sets and frozensets can be produced from any iterable object. Types converting

--- a/docs/structuring.md
+++ b/docs/structuring.md
@@ -154,20 +154,20 @@ to deques are:
 - `Deque[T]`
 - `deque[T]`
 
-In all cases, a new **unbounded** deque (`maxlen=None`) will be returned, so this operation can be used to
-copy an iterable into a deque.
+In all cases, a new **unbounded** deque (`maxlen=None`) will be returned, 
+so this operation can be used to copy an iterable into a deque.
 If you want to convert into bounded `deque`, registering a custom structuring hook is a good approach.
 
 ```{doctest}
 >>> cattrs.structure((1, 2, 3), deque[int])
-[1, 2, 3]
+deque([1, 2, 3])
 ```
 
 These generic types are composable with all other converters.
 
 ```{doctest}
 >>> cattrs.structure((1, None, 3), deque[Optional[str]])
-['1', None, '3']
+deque(['1', None, '3'])
 ```
 
 ```{versionadded} 23.1.0

--- a/docs/unstructuring.md
+++ b/docs/unstructuring.md
@@ -80,9 +80,9 @@ unstructure all sets into lists, try the following:
 Going even further, the Converter contains heuristics to support the
 following Python types, in order of decreasing generality:
 
-- `Sequence`, `MutableSequence`, `list`, `tuple`
+- `Sequence`, `MutableSequence`, `list`, `deque`, `tuple`
 - `Set`, `frozenset`, `MutableSet`, `set`
-- `Mapping`, `MutableMapping`, `dict`, `Counter`
+- `Mapping`, `MutableMapping`, `dict`, `defaultdict`, `OrderedDict`, `Counter`
 
 For example, if you override the unstructure type for `Sequence`, but not for
 `MutableSequence`, `list` or `tuple`, the override will also affect those

--- a/src/cattrs/_compat.py
+++ b/src/cattrs/_compat.py
@@ -178,6 +178,13 @@ if is_py37 or is_py38:
             or (type.__origin__ in (Tuple, tuple) and type.__args__[1] is ...)
         )
 
+    def is_deque(type: Any) -> bool:
+        return (
+            type in (deque, Deque)
+            or (type.__class__ is _GenericAlias and issubclass(type.__origin__, deque))
+            or type.__origin__ is deque
+        )
+
     def is_mutable_set(type):
         return type is set or (
             type.__class__ is _GenericAlias and issubclass(type.__origin__, MutableSet)
@@ -349,7 +356,7 @@ else:
     def is_deque(type):
         return (
             type in (deque, Deque)
-            or (type.__class__ is _GenericAlias and issubclass(type.__origin__, Deque))
+            or (type.__class__ is _GenericAlias and issubclass(type.__origin__, deque))
             or (getattr(type, "__origin__", None) is deque)
         )
 

--- a/src/cattrs/_compat.py
+++ b/src/cattrs/_compat.py
@@ -1,12 +1,13 @@
 import builtins
 import sys
+from collections import deque
 from collections.abc import MutableSet as AbcMutableSet
 from collections.abc import Set as AbcSet
 from dataclasses import MISSING
 from dataclasses import fields as dataclass_fields
 from dataclasses import is_dataclass
 from typing import AbstractSet as TypingAbstractSet
-from typing import Any, Dict, FrozenSet, List
+from typing import Any, Deque, Dict, FrozenSet, List
 from typing import Mapping as TypingMapping
 from typing import MutableMapping as TypingMutableMapping
 from typing import MutableSequence as TypingMutableSequence
@@ -327,8 +328,10 @@ else:
                 TypingSequence,
                 TypingMutableSequence,
                 AbcMutableSequence,
-                Tuple,
                 tuple,
+                Tuple,
+                deque,
+                Deque,
             )
             or (
                 type.__class__ is _GenericAlias
@@ -339,8 +342,15 @@ else:
                     and type.__args__[1] is ...
                 )
             )
-            or (origin in (list, AbcMutableSequence, AbcSequence))
+            or (origin in (list, deque, AbcMutableSequence, AbcSequence))
             or (origin is tuple and type.__args__[1] is ...)
+        )
+
+    def is_deque(type):
+        return (
+            type in (deque, Deque)
+            or (type.__class__ is _GenericAlias and issubclass(type.__origin__, Deque))
+            or (getattr(type, "__origin__", None) is deque)
         )
 
     def is_mutable_set(type):
@@ -370,7 +380,7 @@ else:
 
     def is_mapping(type):
         return (
-            type in (TypingMapping, Dict, TypingMutableMapping, dict, AbcMutableMapping)
+            type in (dict, Dict, TypingMapping, TypingMutableMapping, AbcMutableMapping)
             or (
                 type.__class__ is _GenericAlias
                 and issubclass(type.__origin__, TypingMapping)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,5 +1,7 @@
 """Test both structuring and unstructuring."""
+from collections import deque
 from typing import (
+    Deque,
     FrozenSet,
     List,
     MutableSequence,
@@ -524,20 +526,24 @@ def test_overriding_generated_structure_hook_func():
             (tuple, tuple),
             (list, list),
             (list, List),
+            (deque, Deque),
             (set, Set),
             (set, set),
             (frozenset, frozenset),
             (frozenset, FrozenSet),
             (list, MutableSequence),
+            (deque, MutableSequence),
             (tuple, Sequence),
         ]
         if is_py39_plus
         else [
             (tuple, Tuple),
             (list, List),
+            (deque, Deque),
             (set, Set),
             (frozenset, FrozenSet),
             (list, MutableSequence),
+            (deque, MutableSequence),
             (tuple, Sequence),
         ]
     ),
@@ -561,6 +567,62 @@ def test_seq_of_simple_classes_unstructure(cls_and_vals, seq_type_and_annotation
         else annotation[cl, ...],
     )
     assert all(e == test_val for e in outputs)
+
+
+@given(
+    sampled_from(
+        [
+            (tuple, Tuple),
+            (tuple, tuple),
+            (list, list),
+            (list, List),
+            (deque, deque),
+            (deque, Deque),
+            (set, Set),
+            (set, set),
+            (frozenset, frozenset),
+            (frozenset, FrozenSet),
+        ]
+        if is_py39_plus
+        else [
+            (tuple, Tuple),
+            (list, List),
+            (deque, Deque),
+            (set, Set),
+            (frozenset, FrozenSet),
+        ]
+    )
+)
+def test_seq_of_bare_classes_structure(seq_type_and_annotation):
+    """Structure iterable of values to a sequence of primitives."""
+    converter = Converter()
+
+    cls_and_vals = (
+        (int, (1,), {}),
+        (float, (1.0,), {}),
+        (str, ("test",), {}),
+        (bool, (True,), {}),
+    )
+
+    for cl, vals, kwargs in cls_and_vals:
+
+        @define(frozen=True)
+        class C:
+            a: cl
+
+        seq_type, annotation = seq_type_and_annotation
+
+        inputs = [{"a": cl(*vals, **kwargs)} for _ in range(20)]
+        outputs = converter.structure(
+            inputs,
+            cl=annotation[C]
+            if annotation not in (Tuple, tuple)
+            else annotation[C, ...],
+        )
+        expected = seq_type(C(a=cl(*vals, **kwargs)) for _ in range(20))
+
+        assert type(outputs) == seq_type
+        assert outputs == expected
 
 
 @pytest.mark.skipif(not is_py39_plus, reason="3.9+ only")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -597,29 +597,24 @@ def test_seq_of_bare_classes_structure(seq_type_and_annotation):
     """Structure iterable of values to a sequence of primitives."""
     converter = Converter()
 
-    cls_and_vals = (
-        (int, (1,), {}),
-        (float, (1.0,), {}),
-        (str, ("test",), {}),
-        (bool, (True,), {}),
-    )
+    bare_classes = ((int, (1,)), (float, (1.0,)), (str, ("test",)), (bool, (True,)))
+    seq_type, annotation = seq_type_and_annotation
 
-    for cl, vals, kwargs in cls_and_vals:
+    for cl, vals in bare_classes:
 
         @define(frozen=True)
         class C:
             a: cl
+            b: cl
 
-        seq_type, annotation = seq_type_and_annotation
-
-        inputs = [{"a": cl(*vals, **kwargs)} for _ in range(20)]
+        inputs = [{"a": cl(*vals), "b": cl(*vals)} for _ in range(5)]
         outputs = converter.structure(
             inputs,
             cl=annotation[C]
             if annotation not in (Tuple, tuple)
             else annotation[C, ...],
         )
-        expected = seq_type(C(a=cl(*vals, **kwargs)) for _ in range(20))
+        expected = seq_type(C(a=cl(*vals), b=cl(*vals)) for _ in range(5))
 
         assert type(outputs) == seq_type
         assert outputs == expected

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,4 +1,5 @@
-from typing import Dict, Generic, List, Optional, TypeVar, Union
+from collections import deque
+from typing import Deque, Dict, Generic, List, Optional, TypeVar, Union
 
 import pytest
 from attr import asdict, attrs, define
@@ -141,6 +142,18 @@ def test_structure_list_of_generic_unions(converter):
     data = [TClass2(c="string"), TClass(1, 2)]
     res = converter.structure(
         [asdict(x) for x in data], List[Union[TClass[int, int], TClass2[str]]]
+    )
+    assert res == data
+
+
+def test_structure_deque_of_generic_unions(converter):
+    @attrs(auto_attribs=True)
+    class TClass2(Generic[T]):
+        c: T
+
+    data = deque((TClass2(c="string"), TClass(1, 2)))
+    res = converter.structure(
+        [asdict(x) for x in data], Deque[Union[TClass[int, int], TClass2[str]]]
     )
     assert res == data
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -30,6 +30,7 @@ from .untyped import (
     lists_of_primitives,
     primitive_strategies,
     seqs_of_primitives,
+    deque_seqs_of_primitives,
 )
 
 NoneType = type(None)
@@ -77,6 +78,16 @@ def test_structuring_primitives(primitive_and_type):
 
 @given(seqs_of_primitives)
 def test_structuring_seqs(seq_and_type):
+    """Test structuring sequence generic types."""
+    converter = BaseConverter()
+    iterable, t = seq_and_type
+    converted = converter.structure(iterable, t)
+    for x, y in zip(iterable, converted):
+        assert x == y
+
+
+@given(deque_seqs_of_primitives)
+def test_structuring_seqs_to_deque(seq_and_type):
     """Test structuring sequence generic types."""
     converter = BaseConverter()
     iterable, t = seq_and_type

--- a/tests/test_structure_attrs.py
+++ b/tests/test_structure_attrs.py
@@ -1,9 +1,7 @@
 """Loading of attrs classes."""
-from collections import deque
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from random import randint
-from typing import Deque, Union
+from typing import Union
 from unittest.mock import Mock
 
 import pytest
@@ -78,20 +76,6 @@ def test_structure_tuple(cl_and_vals):
 
     dumped = astuple(obj)
     loaded = converter.structure(dumped, cl)
-
-    assert obj == loaded
-
-
-@given(simple_classes(kw_only=False))
-def test_structure_deque(cl_and_vals):
-    """Structuring of deque works."""
-    converter = BaseConverter()
-    cl, vals, kwargs = cl_and_vals
-    converter.register_structure_hook(cl, converter._structure_deque)
-    obj = deque(cl(*vals, **kwargs) for _ in range(randint(1, 5)))
-
-    dumped = astuple(obj)
-    loaded = converter.structure(dumped, Deque[cl])
 
     assert obj == loaded
 

--- a/tests/test_structure_attrs.py
+++ b/tests/test_structure_attrs.py
@@ -1,7 +1,9 @@
 """Loading of attrs classes."""
+from collections import deque
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from typing import Union
+from random import randint
+from typing import Deque, Union
 from unittest.mock import Mock
 
 import pytest
@@ -76,6 +78,20 @@ def test_structure_tuple(cl_and_vals):
 
     dumped = astuple(obj)
     loaded = converter.structure(dumped, cl)
+
+    assert obj == loaded
+
+
+@given(simple_classes(kw_only=False))
+def test_structure_deque(cl_and_vals):
+    """Structuring of deque works."""
+    converter = BaseConverter()
+    cl, vals, kwargs = cl_and_vals
+    converter.register_structure_hook(cl, converter._structure_deque)
+    obj = deque(cl(*vals, **kwargs) for _ in range(randint(1, 5)))
+
+    dumped = astuple(obj)
+    loaded = converter.structure(dumped, Deque[cl])
 
     assert obj == loaded
 

--- a/tests/untyped.py
+++ b/tests/untyped.py
@@ -77,7 +77,7 @@ def lists_of_primitives(draw):
 def deques_of_primitives(draw):
     """Generate a strategy that yields tuples of list of primitives and types.
 
-    For example, a sample value might be ([1,2], List[int]).
+    For example, a sample value might be ([1,2], Deque[int]).
     """
     prim_strat, t = draw(primitive_strategies)
     deque_t = draw(deque_types.map(lambda deque_t: deque_t[t]) | deque_types)

--- a/tests/untyped.py
+++ b/tests/untyped.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from enum import Enum
 from typing import (
     Any,
+    Deque,
     Dict,
     List,
     Mapping,
@@ -57,6 +58,7 @@ def enums_of_primitives(draw):
 
 
 list_types = st.sampled_from([List, Sequence, MutableSequence])
+deque_types = st.sampled_from([Deque, Sequence, MutableSequence])
 set_types = st.sampled_from([Set, MutableSet])
 
 
@@ -69,6 +71,17 @@ def lists_of_primitives(draw):
     prim_strat, t = draw(primitive_strategies)
     list_t = draw(list_types.map(lambda list_t: list_t[t]) | list_types)
     return draw(st.lists(prim_strat)), list_t
+
+
+@st.composite
+def deques_of_primitives(draw):
+    """Generate a strategy that yields tuples of list of primitives and types.
+
+    For example, a sample value might be ([1,2], List[int]).
+    """
+    prim_strat, t = draw(primitive_strategies)
+    deque_t = draw(deque_types.map(lambda deque_t: deque_t[t]) | deque_types)
+    return draw(st.lists(prim_strat)), deque_t
 
 
 @st.composite
@@ -98,7 +111,7 @@ h_tuples_of_primitives = primitive_strategies.flatmap(
 dict_types = st.sampled_from([Dict, MutableMapping, Mapping])
 
 seqs_of_primitives = st.one_of(lists_of_primitives(), h_tuples_of_primitives)
-
+deque_seqs_of_primitives = st.one_of(deques_of_primitives(), h_tuples_of_primitives)
 sets_of_primitives = st.one_of(mut_sets_of_primitives(), frozen_sets_of_primitives())
 
 


### PR DESCRIPTION
## Env

```
Python==3.10.4
attrs==22.2.0
cattrs==23.1.0.dev0@98ca33ab7
```

## What's the problem

Current head version of `cattrs` work normally to unstructure `deque`, but fails to structure obj into `deque` (or generic `deque`)

Minimal reproducible example:

```python
@define
class C:
    x: int
    y: int

# OK
a = deque((C(x=x, y=y) for x, y in zip(range(10), range(10, 20))))
print(cattrs.unstructure(a))

# Bad
b = ({"x": x, "y": y} for x, y in zip(range(10), range(10, 20)))
print(cattrs.structure(b, deque[C]))
# Traceback (most recent call last):
#   File ".../cattrs/mycase.py", line 33, in <module>
#     main()
#   File ".../cattrs/mycase.py", line 29, in main
#     print(cattrs.structure(a, deque[C]))
#   File ".../cattrs/src/cattrs/converters.py", line 330, in structure
#     return self._structure_func.dispatch(cl)(obj, cl)
#   File ".../cattrs/src/cattrs/converters.py", line 398, in _structure_error
#     raise StructureHandlerNotFoundError(msg, type_=cl)
# cattrs.errors.StructureHandlerNotFoundError: Unsupported type: collections.deque[__main__.C]. Register a structure hook for it.
```

`deque` is a battery-included std container, so I think it's sensible to add a default structure hook for it.

Some notable facts:

```python
print(issubclass(deque, list))
# False
print(issubclass(defaultdict, dict))
# True
```

I once want to also add a structure hook for `defaultdict`, but I thought it's probably difficult to give a factory func for `defaultdict`, which is better to custom by user.

## What this PR does

1. Implement function `_structure_deque()` and `is_deque()`
2. Add related unit tests (`test_structuring`, `test_converters`)
3. Update docs and history.

Suggestions and improvements are appreciated!

Thanks :)
