### PR TITLE
Increase type coverage for Pyright's benefit

### DIFF
--- a/src/cattrs/preconf/bson.py
+++ b/src/cattrs/preconf/bson.py
@@ -22,7 +22,7 @@ class BsonConverter(Converter):
     def dumps(
         self,
         obj: Any,
-        unstructure_as=None,
+        unstructure_as: Any = None,
         check_keys: bool = False,
         codec_options: CodecOptions = DEFAULT_CODEC_OPTIONS,
     ) -> bytes:
@@ -86,7 +86,7 @@ def configure_converter(converter: BaseConverter):
     converter.register_structure_hook(ObjectId, lambda v, _: ObjectId(v))
 
 
-def make_converter(*args, **kwargs) -> BsonConverter:
+def make_converter(*args: Any, **kwargs: Any) -> BsonConverter:
     kwargs["unstruct_collection_overrides"] = {
         AbstractSet: list,
         **kwargs.get("unstruct_collection_overrides", {}),

--- a/src/cattrs/preconf/cbor2.py
+++ b/src/cattrs/preconf/cbor2.py
@@ -12,10 +12,10 @@ T = TypeVar("T")
 
 
 class Cbor2Converter(Converter):
-    def dumps(self, obj: Any, unstructure_as=None, **kwargs) -> bytes:
+    def dumps(self, obj: Any, unstructure_as: Any = None, **kwargs: Any) -> bytes:
         return dumps(self.unstructure(obj, unstructure_as=unstructure_as), **kwargs)
 
-    def loads(self, data: bytes, cl: Type[T], **kwargs) -> T:
+    def loads(self, data: bytes, cl: Type[T], **kwargs: Any) -> T:
         return self.structure(loads(data, **kwargs), cl)
 
 
@@ -32,7 +32,7 @@ def configure_converter(converter: BaseConverter):
     )
 
 
-def make_converter(*args, **kwargs) -> Cbor2Converter:
+def make_converter(*args: Any, **kwargs: Any) -> Cbor2Converter:
     kwargs["unstruct_collection_overrides"] = {
         AbstractSet: list,
         **kwargs.get("unstruct_collection_overrides", {}),

--- a/src/cattrs/preconf/json.py
+++ b/src/cattrs/preconf/json.py
@@ -12,10 +12,10 @@ T = TypeVar("T")
 
 
 class JsonConverter(Converter):
-    def dumps(self, obj: Any, unstructure_as=None, **kwargs) -> str:
+    def dumps(self, obj: Any, unstructure_as: Any = None, **kwargs: Any) -> str:
         return dumps(self.unstructure(obj, unstructure_as=unstructure_as), **kwargs)
 
-    def loads(self, data: Union[bytes, str], cl: Type[T], **kwargs) -> T:
+    def loads(self, data: Union[bytes, str], cl: Type[T], **kwargs: Any) -> T:
         return self.structure(loads(data, **kwargs), cl)
 
 
@@ -36,7 +36,7 @@ def configure_converter(converter: BaseConverter):
     converter.register_structure_hook(datetime, lambda v, _: datetime.fromisoformat(v))
 
 
-def make_converter(*args, **kwargs) -> JsonConverter:
+def make_converter(*args: Any, **kwargs: Any) -> JsonConverter:
     kwargs["unstruct_collection_overrides"] = {
         AbstractSet: list,
         Counter: dict,

--- a/src/cattrs/preconf/msgpack.py
+++ b/src/cattrs/preconf/msgpack.py
@@ -12,10 +12,10 @@ T = TypeVar("T")
 
 
 class MsgpackConverter(Converter):
-    def dumps(self, obj: Any, unstructure_as=None, **kwargs) -> bytes:
+    def dumps(self, obj: Any, unstructure_as: Any = None, **kwargs: Any) -> bytes:
         return dumps(self.unstructure(obj, unstructure_as=unstructure_as), **kwargs)
 
-    def loads(self, data: bytes, cl: Type[T], **kwargs) -> T:
+    def loads(self, data: bytes, cl: Type[T], **kwargs: Any) -> T:
         return self.structure(loads(data, **kwargs), cl)
 
 
@@ -32,7 +32,7 @@ def configure_converter(converter: BaseConverter):
     )
 
 
-def make_converter(*args, **kwargs) -> MsgpackConverter:
+def make_converter(*args: Any, **kwargs: Any) -> MsgpackConverter:
     kwargs["unstruct_collection_overrides"] = {
         AbstractSet: list,
         **kwargs.get("unstruct_collection_overrides", {}),

--- a/src/cattrs/preconf/orjson.py
+++ b/src/cattrs/preconf/orjson.py
@@ -14,7 +14,7 @@ T = TypeVar("T")
 
 
 class OrjsonConverter(Converter):
-    def dumps(self, obj: Any, unstructure_as=None, **kwargs) -> bytes:
+    def dumps(self, obj: Any, unstructure_as: Any = None, **kwargs: Any) -> bytes:
         return dumps(self.unstructure(obj, unstructure_as=unstructure_as), **kwargs)
 
     def loads(self, data: bytes, cl: Type[T]) -> T:
@@ -66,7 +66,7 @@ def configure_converter(converter: BaseConverter):
     )
 
 
-def make_converter(*args, **kwargs) -> OrjsonConverter:
+def make_converter(*args: Any, **kwargs: Any) -> OrjsonConverter:
     kwargs["unstruct_collection_overrides"] = {
         AbstractSet: list,
         **kwargs.get("unstruct_collection_overrides", {}),

--- a/src/cattrs/preconf/pyyaml.py
+++ b/src/cattrs/preconf/pyyaml.py
@@ -13,7 +13,7 @@ T = TypeVar("T")
 
 
 class PyyamlConverter(Converter):
-    def dumps(self, obj: Any, unstructure_as=None, **kwargs) -> str:
+    def dumps(self, obj: Any, unstructure_as: Any = None, **kwargs: Any) -> str:
         return safe_dump(self.unstructure(obj, unstructure_as=unstructure_as), **kwargs)
 
     def loads(self, data: str, cl: Type[T]) -> T:
@@ -33,7 +33,7 @@ def configure_converter(converter: BaseConverter):
     converter.register_structure_hook(datetime, validate_datetime)
 
 
-def make_converter(*args, **kwargs) -> PyyamlConverter:
+def make_converter(*args: Any, **kwargs: Any) -> PyyamlConverter:
     kwargs["unstruct_collection_overrides"] = {
         FrozenSetSubscriptable: list,
         **kwargs.get("unstruct_collection_overrides", {}),

--- a/src/cattrs/preconf/tomlkit.py
+++ b/src/cattrs/preconf/tomlkit.py
@@ -17,7 +17,7 @@ _enum_value_getter = attrgetter("_value_")
 
 
 class TomlkitConverter(Converter):
-    def dumps(self, obj: Any, unstructure_as=None, **kwargs) -> str:
+    def dumps(self, obj: Any, unstructure_as: Any = None, **kwargs: Any) -> str:
         return dumps(self.unstructure(obj, unstructure_as=unstructure_as), **kwargs)
 
     def loads(self, data: str, cl: Type[T]) -> T:
@@ -65,7 +65,7 @@ def configure_converter(converter: BaseConverter):
     converter.register_structure_hook(datetime, validate_datetime)
 
 
-def make_converter(*args, **kwargs) -> TomlkitConverter:
+def make_converter(*args: Any, **kwargs: Any) -> TomlkitConverter:
     kwargs["unstruct_collection_overrides"] = {
         AbstractSet: list,
         tuple: list,

--- a/src/cattrs/preconf/ujson.py
+++ b/src/cattrs/preconf/ujson.py
@@ -13,10 +13,10 @@ T = TypeVar("T")
 
 
 class UjsonConverter(Converter):
-    def dumps(self, obj: Any, unstructure_as=None, **kwargs) -> str:
+    def dumps(self, obj: Any, unstructure_as: Any = None, **kwargs: Any) -> str:
         return dumps(self.unstructure(obj, unstructure_as=unstructure_as), **kwargs)
 
-    def loads(self, data: AnyStr, cl: Type[T], **kwargs) -> T:
+    def loads(self, data: AnyStr, cl: Type[T], **kwargs: Any) -> T:
         return self.structure(loads(data, **kwargs), cl)
 
 
@@ -37,7 +37,7 @@ def configure_converter(converter: BaseConverter):
     converter.register_structure_hook(datetime, lambda v, _: datetime.fromisoformat(v))
 
 
-def make_converter(*args, **kwargs) -> UjsonConverter:
+def make_converter(*args: Any, **kwargs: Any) -> UjsonConverter:
     kwargs["unstruct_collection_overrides"] = {
         AbstractSet: list,
         **kwargs.get("unstruct_collection_overrides", {}),


### PR DESCRIPTION
This isn't really a material improvement but Pyright does not infer the type of un-annotated parameters to be `Any` and produces an error at call site.