### PR TITLE
ISO-8601 support for preconfigured converters

### DIFF
--- a/src/cattrs/preconf/json.py
+++ b/src/cattrs/preconf/json.py
@@ -1,6 +1,6 @@
 """Preconfigured converters for the stdlib json."""
 from base64 import b85decode, b85encode
-from datetime import datetime
+from datetime import datetime, date, time
 from json import dumps, loads
 from typing import Any, Type, TypeVar, Union
 
@@ -24,7 +24,7 @@ def configure_converter(converter: BaseConverter):
     Configure the converter for use with the stdlib json module.
 
     * bytes are serialized as base64 strings
-    * datetimes are serialized as ISO 8601
+    * datetimes, dates, times are serialized as ISO 8601
     * counters are serialized as dicts
     * sets are serialized as lists
     """
@@ -34,6 +34,12 @@ def configure_converter(converter: BaseConverter):
     converter.register_structure_hook(bytes, lambda v, _: b85decode(v))
     converter.register_unstructure_hook(datetime, lambda v: v.isoformat())
     converter.register_structure_hook(datetime, lambda v, _: datetime.fromisoformat(v))
+
+    converter.register_unstructure_hook(date, lambda v: v.isoformat())
+    converter.register_structure_hook(date, lambda v, _: date.fromisoformat(v))
+
+    converter.register_unstructure_hook(time, lambda v: v.isoformat())
+    converter.register_structure_hook(time, lambda v, _: time.fromisoformat(v))
 
 
 def make_converter(*args: Any, **kwargs: Any) -> JsonConverter:

--- a/src/cattrs/preconf/orjson.py
+++ b/src/cattrs/preconf/orjson.py
@@ -1,6 +1,6 @@
 """Preconfigured converters for orjson."""
 from base64 import b85decode, b85encode
-from datetime import datetime
+from datetime import datetime, date, time
 from enum import Enum
 from typing import Any, Type, TypeVar
 
@@ -26,7 +26,7 @@ def configure_converter(converter: BaseConverter):
     Configure the converter for use with the orjson library.
 
     * bytes are serialized as base85 strings
-    * datetimes are serialized as ISO 8601
+    * datetimes, dates, times are serialized as ISO 8601
     * sets are serialized as lists
     * string enum mapping keys have special handling
     * mapping keys are coerced into strings when unstructuring
@@ -38,6 +38,12 @@ def configure_converter(converter: BaseConverter):
 
     converter.register_unstructure_hook(datetime, lambda v: v.isoformat())
     converter.register_structure_hook(datetime, lambda v, _: datetime.fromisoformat(v))
+
+    converter.register_unstructure_hook(date, lambda v: v.isoformat())
+    converter.register_structure_hook(date, lambda v, _: date.fromisoformat(v))
+
+    converter.register_unstructure_hook(time, lambda v: v.isoformat())
+    converter.register_structure_hook(time, lambda v, _: time.fromisoformat(v))
 
     def gen_unstructure_mapping(cl: Any, unstructure_to=None):
         key_handler = str

--- a/src/cattrs/preconf/ujson.py
+++ b/src/cattrs/preconf/ujson.py
@@ -1,6 +1,6 @@
 """Preconfigured converters for ujson."""
 from base64 import b85decode, b85encode
-from datetime import datetime
+from datetime import datetime, date, time
 from typing import Any, AnyStr, Type, TypeVar
 
 from ujson import dumps, loads
@@ -25,7 +25,7 @@ def configure_converter(converter: BaseConverter):
     Configure the converter for use with the ujson library.
 
     * bytes are serialized as base64 strings
-    * datetimes are serialized as ISO 8601
+    * datetimes, dates, times are serialized as ISO 8601
     * sets are serialized as lists
     """
     converter.register_unstructure_hook(
@@ -35,6 +35,12 @@ def configure_converter(converter: BaseConverter):
 
     converter.register_unstructure_hook(datetime, lambda v: v.isoformat())
     converter.register_structure_hook(datetime, lambda v, _: datetime.fromisoformat(v))
+
+    converter.register_unstructure_hook(date, lambda v: v.isoformat())
+    converter.register_structure_hook(date, lambda v, _: date.fromisoformat(v))
+
+    converter.register_unstructure_hook(time, lambda v: v.isoformat())
+    converter.register_structure_hook(time, lambda v, _: time.fromisoformat(v))
 
 
 def make_converter(*args: Any, **kwargs: Any) -> UjsonConverter:


### PR DESCRIPTION
Serialize and deserialize dates and times to ISO-8601 format in preconfigured converters. Only added this functionality to those preconfigured converters that already use datatime conversion to/from ISO-8601