### PR TITLE
Fix type checker error

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 - _cattrs_ is now linted with [Ruff](https://beta.ruff.rs/docs/).
 - Fix TypedDicts with periods in their field names.
   ([#376](https://github.com/python-attrs/cattrs/issues/376) [#377](https://github.com/python-attrs/cattrs/pull/377))
+- Fix `format_exception` and `transform_error` type annotations.
 
 ## 23.1.2 (2023-06-02)
 

--- a/src/cattrs/v.py
+++ b/src/cattrs/v.py
@@ -1,5 +1,5 @@
 """Cattrs validation."""
-from typing import Callable, List, Type, Union
+from typing import Callable, List, Union
 
 from .errors import (
     ClassValidationError,
@@ -10,7 +10,7 @@ from .errors import (
 __all__ = ["format_exception", "transform_error"]
 
 
-def format_exception(exc: BaseException, type: Union[Type, None]) -> str:
+def format_exception(exc: BaseException, type: Union[type, None]) -> str:
     """The default exception formatter, handling the most common exceptions.
 
     The following exceptions are handled specially:
@@ -61,7 +61,7 @@ def transform_error(
     exc: Union[ClassValidationError, IterableValidationError, BaseException],
     path: str = "$",
     format_exception: Callable[
-        [BaseException, Union[Type, None]], str
+        [BaseException, Union[type, None]], str
     ] = format_exception,
 ) -> List[str]:
     """Transform an exception into a list of error messages.


### PR DESCRIPTION
Pyright expects `typing.Type` to be parameterised and reports that the function's type is unknown.