### PR TITLE
Make `BaseValidationError` base static in Python < 3.11

### DIFF
--- a/src/cattrs/_compat.py
+++ b/src/cattrs/_compat.py
@@ -1,4 +1,3 @@
-import builtins
 import sys
 from collections import deque
 from collections.abc import MutableSet as AbcMutableSet
@@ -62,10 +61,10 @@ if is_py37:
 else:
     from typing import Final, Protocol, get_args, get_origin
 
-if "ExceptionGroup" not in dir(builtins):
-    from exceptiongroup import ExceptionGroup
-else:
+if is_py311_plus:
     ExceptionGroup = ExceptionGroup
+else:
+    from exceptiongroup import ExceptionGroup
 
 
 def has(cls):

--- a/src/cattrs/_compat.py
+++ b/src/cattrs/_compat.py
@@ -64,7 +64,7 @@ else:
 if is_py311_plus:
     ExceptionGroup = ExceptionGroup
 else:
-    from exceptiongroup import ExceptionGroup
+    from exceptiongroup import ExceptionGroup as ExceptionGroup  # noqa: PLC0414
 
 
 def has(cls):


### PR DESCRIPTION
Unsure if this worked in MyPy but Pyright failed to resolve the base of `BaseValidationError` subclasses leading to hard to trace type errors in custom note attributes from failing to narrow Iterable and ClassValidationError unions.