### PR TITLE
Make Python versions known statically

### DIFF
--- a/src/cattrs/gen/typeddicts.py
+++ b/src/cattrs/gen/typeddicts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import linecache
 import re
+import sys
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from attr import NOTHING, Attribute
@@ -34,8 +35,6 @@ from .._compat import (
     is_annotated,
     is_bare,
     is_generic,
-    is_py39_plus,
-    is_py311_plus,
 )
 from .._generics import deep_copy_with
 from ..errors import (
@@ -533,12 +532,12 @@ def _is_extensions_typeddict(cls) -> bool:
     )
 
 
-if is_py311_plus:
+if sys.version_info >= (3, 11):
 
     def _required_keys(cls: type) -> set[str]:
         return cls.__required_keys__
 
-elif is_py39_plus:
+elif sys.version_info >= (3, 9):
     from typing_extensions import Annotated, NotRequired, Required, get_args
 
     def _required_keys(cls: type) -> set[str]:

--- a/tests/_compat.py
+++ b/tests/_compat.py
@@ -1,4 +1,10 @@
-from cattrs._compat import is_py37, is_py38
+import sys
+
+is_py37 = sys.version_info[:2] == (3, 7)
+is_py38 = sys.version_info[:2] == (3, 8)
+is_py39_plus = sys.version_info >= (3, 9)
+is_py310_plus = sys.version_info >= (3, 10)
+is_py311_plus = sys.version_info >= (3, 11)
 
 if is_py37 or is_py38:
     from typing import Dict, List

--- a/tests/test_baseconverter.py
+++ b/tests/test_baseconverter.py
@@ -8,8 +8,8 @@ from hypothesis import HealthCheck, assume, given, settings
 from hypothesis.strategies import just, one_of
 
 from cattrs import BaseConverter, UnstructureStrategy
-from cattrs._compat import is_py310_plus
 
+from ._compat import is_py310_plus
 from .typed import nested_typed_classes, simple_typed_attrs, simple_typed_classes
 
 unstructure_strats = one_of(just(s) for s in UnstructureStrategy)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -19,10 +19,10 @@ from hypothesis import HealthCheck, assume, given, settings
 from hypothesis.strategies import booleans, just, lists, one_of, sampled_from
 
 from cattrs import Converter, UnstructureStrategy
-from cattrs._compat import is_py39_plus, is_py310_plus
 from cattrs.errors import ClassValidationError, ForbiddenExtraKeysError
 from cattrs.gen import make_dict_structure_fn, override
 
+from ._compat import is_py39_plus, is_py310_plus
 from .typed import (
     nested_typed_classes,
     simple_typed_attrs,

--- a/tests/test_gen_dict.py
+++ b/tests/test_gen_dict.py
@@ -8,10 +8,11 @@ from hypothesis import assume, given
 from hypothesis.strategies import data, just, one_of, sampled_from
 
 from cattrs import BaseConverter, Converter
-from cattrs._compat import _adapted_fields, fields, is_py39_plus
+from cattrs._compat import _adapted_fields, fields
 from cattrs.errors import ClassValidationError, ForbiddenExtraKeysError
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
 
+from ._compat import is_py39_plus
 from .typed import nested_typed_classes, simple_typed_classes, simple_typed_dataclasses
 from .untyped import nested_classes, simple_classes
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -5,12 +5,18 @@ import pytest
 from attr import asdict, attrs, define
 
 from cattrs import BaseConverter, Converter
-from cattrs._compat import Protocol, is_py39_plus, is_py310_plus, is_py311_plus
+from cattrs._compat import Protocol
 from cattrs._generics import deep_copy_with
 from cattrs.errors import StructureHandlerNotFoundError
 from cattrs.gen._generics import generate_mapping
 
-from ._compat import Dict_origin, List_origin
+from ._compat import (
+    Dict_origin,
+    List_origin,
+    is_py39_plus,
+    is_py310_plus,
+    is_py311_plus,
+)
 
 T = TypeVar("T")
 T2 = TypeVar("T2")

--- a/tests/test_optionals.py
+++ b/tests/test_optionals.py
@@ -3,7 +3,7 @@ from typing import NewType, Optional
 import pytest
 from attrs import define
 
-from cattrs._compat import is_py310_plus
+from ._compat import is_py310_plus
 
 
 def test_newtype_optionals(genconverter):

--- a/tests/test_structure_attrs.py
+++ b/tests/test_structure_attrs.py
@@ -9,9 +9,9 @@ from attr import NOTHING, Factory, asdict, astuple, attrib, define, fields, make
 from hypothesis import assume, given
 from hypothesis.strategies import data, lists, sampled_from
 
-from cattrs._compat import is_py37
 from cattrs.converters import BaseConverter, Converter
 
+from ._compat import is_py37
 from .untyped import simple_classes
 
 

--- a/tests/test_typeddicts.py
+++ b/tests/test_typeddicts.py
@@ -8,7 +8,7 @@ from hypothesis.strategies import booleans
 from pytest import raises
 
 from cattrs import Converter
-from cattrs._compat import ExtensionsTypedDict, is_generic, is_py38, is_py311_plus
+from cattrs._compat import ExtensionsTypedDict, is_generic
 from cattrs.errors import ClassValidationError, ForbiddenExtraKeysError
 from cattrs.gen import override
 from cattrs.gen._generics import generate_mapping
@@ -18,6 +18,7 @@ from cattrs.gen.typeddicts import (
     make_dict_unstructure_fn,
 )
 
+from ._compat import is_py38, is_py311_plus
 from .typeddicts import (
     generic_typeddicts,
     simple_typeddicts,

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -3,8 +3,9 @@ from typing import Type, Union
 import attr
 import pytest
 
-from cattrs._compat import is_py310_plus
 from cattrs.converters import BaseConverter, Converter
+
+from ._compat import is_py310_plus
 
 
 @pytest.mark.parametrize("cls", (BaseConverter, Converter))

--- a/tests/test_unstructure_collections.py
+++ b/tests/test_unstructure_collections.py
@@ -14,8 +14,9 @@ import pytest
 from immutables import Map
 
 from cattrs import Converter
-from cattrs._compat import is_py39_plus
 from cattrs.converters import is_mutable_set, is_sequence
+
+from ._compat import is_py39_plus
 
 
 @pytest.mark.skipif(not is_py39_plus, reason="Requires Python 3.9+")


### PR DESCRIPTION
Type checkers are unable to interpret `sys.version_info` aliases and generate unions between Python version branches.  If either branch depends on packages which are not installed the union might be reduced to an unknown or any type.

Follow-up from https://github.com/python-attrs/cattrs/pull/379 (Pyright would merge the two branches).