### PR TITLE
Don't try to upload coverage if CI is run via workflow dispatch on a fork

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: "Upload coverage to Codecov"
         # if: "contains(env.USING_COVERAGE, matrix.python-version)"
+        if: github.repository == 'python-attrs/cattrs'
         uses: "codecov/codecov-action@v1"
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
While investigating https://github.com/python/typing_extensions/issues/230 and preparing #384, I tried running cattrs's CI on my fork via workflow-dispatch. This was made a little more complicated by the fact that the "upload coverage to codecov" step always seems to fail when the workflow is run on a fork