### PR TITLE
Don't cancel all jobs in CI if one job fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
+      fail-fast: false
 
     steps:
       - uses: "actions/checkout@v2"


### PR DESCRIPTION
This will make it easier to see in #384 which tests (if any) are actually failing on which Python versions -- currently the codecov failures are just leading to all jobs being cancelled in CI