### PR TITLE
Implement a disambiguator for discriminated unions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,8 @@
 - Improve handling of TypedDicts with forward references.
 - Speed up generated _attrs_ and TypedDict structuring functions by changing their signature slightly.
   ([#388](https://github.com/python-attrs/cattrs/pull/388))
+- Disambiguate a union of attrs classes where there's a `typing.Literal` tag of some sort.
+  ([#391](https://github.com/python-attrs/cattrs/pull/391))
 
 ## 23.1.2 (2023-06-02)
 

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,9 @@ clean-test: ## remove test and coverage artifacts
 	rm -f .coverage
 	rm -fr htmlcov/
 
-lint: ## check style with flake8
+lint: ## check style with ruff, isort, and black
 	pdm run ruff src/ tests
+	pdm run isort --check src/ tests docs/conf.py
 	pdm run black --check src tests docs/conf.py
 
 test: ## run tests quickly with the default Python

--- a/src/cattrs/disambiguators.py
+++ b/src/cattrs/disambiguators.py
@@ -1,12 +1,12 @@
 """Utilities for union (sum type) disambiguation."""
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from functools import reduce
 from operator import or_
-from typing import Any, Callable, Dict, Mapping, Optional, Type
+from typing import Any, Callable, Dict, Mapping, Optional, Type, Union
 
-from attr import NOTHING, fields
+from attr import NOTHING, fields, fields_dict
 
-from cattrs._compat import get_origin
+from cattrs._compat import get_args, get_origin, is_literal
 
 
 def create_uniq_field_dis_func(
@@ -15,6 +15,8 @@ def create_uniq_field_dis_func(
     """Given attr classes, generate a disambiguation function.
 
     The function is based on unique fields."""
+    # NOTE: This could just as well work with just field availability and not
+    #  uniqueness, returning Unions ... it doesn't do that right now.
     if len(classes) < 2:
         raise ValueError("At least two classes required.")
     cls_and_attrs = [
@@ -55,5 +57,66 @@ def create_uniq_field_dis_func(
             if k in data:
                 return v
         return fallback
+
+    return dis_func
+
+
+def create_discriminated_dis_func(
+    *classes: Type[Any],
+) -> Callable[[Mapping[Any, Any]], Optional[Type[Any]]]:
+    """Given attr classes, generate a disambiguation function.
+
+    The function is based on having a shared discriminator."""
+    if len(classes) < 2:
+        raise ValueError("At least two classes required.")
+
+    # requirements for a discriminator field:
+    # (... TODO: a single fallback is OK)
+    #  - it must be *required*
+    #  - it must always be enumerated
+    cls_candidates = [
+        {
+            at.name
+            for at in fields(get_origin(cl) or cl)
+            if at.default is NOTHING and is_literal(at.type)
+        }
+        for cl in classes
+    ]
+
+    discriminators = cls_candidates[0]
+    for possible_discriminators in cls_candidates:
+        discriminators &= possible_discriminators
+
+    if not discriminators:
+        raise ValueError("No shared discriminator found")
+
+    best_result = None
+    best_discriminator = None
+    for discriminator in discriminators:
+        mapping = defaultdict(list)
+
+        for cl in classes:
+            for key in get_args(fields_dict(get_origin(cl) or cl)[discriminator].type):
+                mapping[key].append(cl)
+
+        if best_result is None or max(len(v) for v in mapping.values()) <= max(
+            len(v) for v in best_result.values()
+        ):
+            best_result = mapping
+            best_discriminator = discriminator
+
+    assert best_result
+    assert best_discriminator
+    if max(len(v) for v in best_result.values()) == len(classes):
+        raise ValueError("No discriminator found that narrows down classes")
+
+    final_mapping = {
+        k: v[0] if len(v) == 1 else Union[tuple(v)] for k, v in best_result.items()
+    }
+
+    def dis_func(data: Mapping[Any, Any]) -> Optional[Type]:
+        if not isinstance(data, Mapping):
+            raise ValueError("Only input mappings are supported.")
+        return final_mapping[data[best_discriminator]]
 
     return dis_func

--- a/tests/test_disambigutors.py
+++ b/tests/test_disambigutors.py
@@ -1,17 +1,24 @@
 """Tests for auto-disambiguators."""
-from typing import Any
+from typing import Any, Union
 
 import attr
 import pytest
-from attr import NOTHING
+from attrs import NOTHING, define
 from hypothesis import HealthCheck, assume, given, settings
 
-from cattrs.disambiguators import create_uniq_field_dis_func
+from cattrs.disambiguators import (
+    create_discriminated_dis_func,
+    create_uniq_field_dis_func,
+)
 
+from ._compat import is_py37
 from .untyped import simple_classes
 
 
+@pytest.mark.skipif(is_py37, reason="Not supported on 3.7")
 def test_edge_errors():
+    from typing import Literal
+
     """Edge input cases cause errors."""
 
     @attr.s
@@ -22,6 +29,9 @@ def test_edge_errors():
         # Can't generate for only one class.
         create_uniq_field_dis_func(A)
 
+    with pytest.raises(ValueError):
+        create_discriminated_dis_func(A)
+
     @attr.s
     class B:
         pass
@@ -29,6 +39,9 @@ def test_edge_errors():
     with pytest.raises(ValueError):
         # No fields on either class.
         create_uniq_field_dis_func(A, B)
+
+    with pytest.raises(ValueError):
+        create_discriminated_dis_func(A, B)
 
     @attr.s
     class C:
@@ -42,6 +55,10 @@ def test_edge_errors():
         # No unique fields on either class.
         create_uniq_field_dis_func(C, D)
 
+    with pytest.raises(ValueError):
+        # No discriminator candidates
+        create_discriminated_dis_func(C, D)
+
     @attr.s
     class E:
         pass
@@ -53,6 +70,18 @@ def test_edge_errors():
     with pytest.raises(ValueError):
         # no usable non-default attributes
         create_uniq_field_dis_func(E, F)
+
+    @define()
+    class G:
+        x: Literal[1]
+
+    @define()
+    class H:
+        x: Literal[1]
+
+    with pytest.raises(ValueError):
+        # The discriminator chosen does not actually help
+        create_discriminated_dis_func(C, D)
 
 
 @given(simple_classes(defaults=False))
@@ -99,3 +128,74 @@ def test_disambiguation(cl_and_vals_a, cl_and_vals_b):
     fn = create_uniq_field_dis_func(cl_a, cl_b)
 
     assert fn(attr.asdict(cl_a(*vals_a, **kwargs_a))) is cl_a
+
+
+# not too sure of properties of `create_discriminated_dis_func`
+@pytest.mark.skipif(is_py37, reason="Not supported on 3.7")
+def test_disambiguate_from_discriminated_enum():
+    from typing import Literal
+
+    # can it find any discriminator?
+    @define()
+    class A:
+        a: Literal[0]
+
+    @define()
+    class B:
+        a: Literal[1]
+
+    fn = create_discriminated_dis_func(A, B)
+    assert fn({"a": 0}) is A
+    assert fn({"a": 1}) is B
+
+    # can it find the better discriminator?
+    @define()
+    class C:
+        a: Literal[0]
+        b: Literal[1]
+
+    @define()
+    class D:
+        a: Literal[0]
+        b: Literal[0]
+
+    fn = create_discriminated_dis_func(C, D)
+    assert fn({"a": 0, "b": 1}) is C
+    assert fn({"a": 0, "b": 0}) is D
+
+    # can it handle multiple tiers of discriminators?
+    # (example inspired by Discord's gateway's discriminated union)
+    @define()
+    class E:
+        op: Literal[1]
+
+    @define()
+    class F:
+        op: Literal[0]
+        t: Literal["MESSAGE_CREATE"]
+
+    @define()
+    class G:
+        op: Literal[0]
+        t: Literal["MESSAGE_UPDATE"]
+
+    fn = create_discriminated_dis_func(E, F, G)
+    assert fn({"op": 1}) is E
+    assert fn({"op": 0, "t": "MESSAGE_CREATE"}) is Union[F, G]
+
+    # can it handle multiple literals?
+    @define()
+    class H:
+        a: Literal[1]
+
+    @define()
+    class J:
+        a: Literal[0, 1]
+
+    @define()
+    class K:
+        a: Literal[0]
+
+    fn = create_discriminated_dis_func(H, J, K)
+    assert fn({"a": 1}) is Union[H, J]
+    assert fn({"a": 0}) is Union[J, K]

--- a/tests/test_structure_attrs.py
+++ b/tests/test_structure_attrs.py
@@ -308,3 +308,31 @@ def test_structure_prefers_attrib_converters(converter_type):
 
     attrib_converter.assert_any_call(5)
     assert inst.z == "5"
+
+
+@pytest.mark.skipif(is_py37, reason="Not supported on 3.7")
+@pytest.mark.parametrize("converter_type", [BaseConverter, Converter])
+def test_structure_multitier_discriminator_union(converter_type):
+    from typing import Literal
+
+    converter = converter_type()
+
+    @define()
+    class E:
+        op: Literal[1]
+
+    @define()
+    class F:
+        op: Literal[0]
+        t: Literal["MESSAGE_CREATE"]
+
+    @define()
+    class G:
+        op: Literal[0]
+        t: Literal["MESSAGE_UPDATE"]
+
+    inst = converter.structure({"op": 1}, Union[E, F, G])
+    assert isinstance(inst, E)
+
+    inst = converter.structure({"op": 0, "t": "MESSAGE_CREATE"}, Union[E, F, G])
+    assert isinstance(inst, F)


### PR DESCRIPTION
Another way at "tagged unions" except backwards compatible! Also, a ton of services provide data in this fashion. Debatably cattrs already does something similar where you don't need to register a structure hook for a `Literal[1, 2, 3, 4]` or whatever.

Look at the tests for some examples!