### PR TITLE
Broaden method type definition for preconf orjson converter.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,6 +24,8 @@
   ([#388](https://github.com/python-attrs/cattrs/pull/388))
 - Fix copying of converters using function hooks.
   ([#398](https://github.com/python-attrs/cattrs/issues/398) [#399](https://github.com/python-attrs/cattrs/pull/399))
+- Broaden loads' type definition for the preconf orjson converter.
+  ([#400](https://github.com/python-attrs/cattrs/pull/400))
 
 ## 23.1.2 (2023-06-02)
 

--- a/src/cattrs/preconf/orjson.py
+++ b/src/cattrs/preconf/orjson.py
@@ -2,7 +2,7 @@
 from base64 import b85decode, b85encode
 from datetime import datetime
 from enum import Enum
-from typing import Any, Type, TypeVar
+from typing import Any, Type, TypeVar, Union
 
 from orjson import dumps, loads
 
@@ -17,7 +17,7 @@ class OrjsonConverter(Converter):
     def dumps(self, obj: Any, unstructure_as: Any = None, **kwargs: Any) -> bytes:
         return dumps(self.unstructure(obj, unstructure_as=unstructure_as), **kwargs)
 
-    def loads(self, data: bytes, cl: Type[T]) -> T:
+    def loads(self, data: Union[bytes, bytearray, memoryview, str], cl: Type[T]) -> T:
         return self.structure(loads(data), cl)
 
 


### PR DESCRIPTION
`bytes` is not the only input type `orjson.loads` allows.