### PR TITLE
Fix typeddict tests on systems with 32-bit time_t

### DIFF
--- a/tests/typeddicts.py
+++ b/tests/typeddicts.py
@@ -59,7 +59,9 @@ def int_attributes(
 def datetime_attributes(
     draw: DrawFn, total: bool = True, not_required: bool = False
 ) -> Tuple[datetime, SearchStrategy, SearchStrategy]:
-    success_strat = datetimes().map(lambda dt: dt.replace(microsecond=0))
+    success_strat = datetimes(
+        min_value=datetime(1970, 1, 1), max_value=datetime(2038, 1, 1)
+    ).map(lambda dt: dt.replace(microsecond=0))
     type = datetime
     strat = success_strat if total else success_strat | just(NOTHING)
     if not_required and draw(booleans()):


### PR DESCRIPTION
Reduce the range of generated `datetime` instances to values valid for 32-bit `time_t` range, as otherwise multiple tests fail with errors such as:

    FAILED tests/test_typeddicts.py::test_simple_roundtrip - OverflowError: timestamp out of range for platform time_t

This is based on an earlier fix for `test_preconf.py`, see a0e56f43f061c43814d6f938833d1c325ed61525
and c58028789454fc7a9b459b94c214cab2ab1acb81.

Originally reported as https://bugs.gentoo.org/912187.