### PR TITLE
Fix include_subclass union_strategy typing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -51,6 +51,8 @@ Our backwards-compatibility policy can be found [here](https://github.com/python
 - The documentation has been significantly reworked.
   ([#473](https://github.com/python-attrs/cattrs/pull/473))
 - The docs now use the Inter font.
+- Make type annotations for `include_subclasses` and `tagged_union` strategies more lenient.
+  ([#431](https://github.com/python-attrs/cattrs/pull/431))
 
 ## 23.2.3 (2023-11-30)
 

--- a/src/cattrs/strategies/_subclasses.py
+++ b/src/cattrs/strategies/_subclasses.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 from gc import collect
-from typing import Any, Callable, Union
+from typing import Any, Callable, Union, TypeVar
 
-from ..converters import BaseConverter, Converter
+from ..converters import BaseConverter
 from ..gen import AttributeOverride, make_dict_structure_fn, make_dict_unstructure_fn
 from ..gen._consts import already_generating
 
@@ -28,11 +28,14 @@ def _get_union_type(cl: type, given_subclasses_tree: tuple[type]) -> type | None
     return Union[class_tree] if len(class_tree) >= 2 else None
 
 
+C = TypeVar("C", bound=BaseConverter)
+
+
 def include_subclasses(
     cl: type,
-    converter: Converter,
+    converter: C,
     subclasses: tuple[type, ...] | None = None,
-    union_strategy: Callable[[Any, BaseConverter], Any] | None = None,
+    union_strategy: Callable[[Any, C], Any] | None = None,
     overrides: dict[str, AttributeOverride] | None = None,
 ) -> None:
     """
@@ -79,7 +82,7 @@ def include_subclasses(
 
 def _include_subclasses_without_union_strategy(
     cl,
-    converter: Converter,
+    converter: BaseConverter,
     parent_subclass_tree: tuple[type],
     overrides: dict[str, AttributeOverride] | None,
 ):
@@ -153,9 +156,9 @@ def _include_subclasses_without_union_strategy(
 
 
 def _include_subclasses_with_union_strategy(
-    converter: Converter,
+    converter: C,
     union_classes: tuple[type, ...],
-    union_strategy: Callable[[Any, BaseConverter], Any],
+    union_strategy: Callable[[Any, C], Any],
     overrides: dict[str, AttributeOverride] | None,
 ):
     """

--- a/src/cattrs/strategies/_subclasses.py
+++ b/src/cattrs/strategies/_subclasses.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from gc import collect
-from typing import Any, Callable, Union, TypeVar
+from typing import Any, Callable, TypeVar, Union
 
 from ..converters import BaseConverter
 from ..gen import AttributeOverride, make_dict_structure_fn, make_dict_unstructure_fn

--- a/src/cattrs/strategies/_unions.py
+++ b/src/cattrs/strategies/_unions.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, Optional, Type, Union
 
 from attrs import NOTHING
 
-from cattrs import BaseConverter, Converter
+from cattrs import BaseConverter
 from cattrs._compat import get_newtype_base, is_literal, is_subclass, is_union_type
 
 __all__ = [
@@ -20,7 +20,7 @@ def default_tag_generator(typ: Type) -> str:
 
 def configure_tagged_union(
     union: Any,
-    converter: Converter,
+    converter: BaseConverter,
     tag_generator: Callable[[Type], str] = default_tag_generator,
     tag_name: str = "_type",
     default: Optional[Type] = NOTHING,


### PR DESCRIPTION
Using Converter instead of BaseConverter as one of the arguments to union_strategy allows more strategies to be passed. Specifically, the configure_tagged_union strategy currently requires a Converter according to its typing.