### PR TITLE
Add a regression test for a nested tagged union scenario

### DIFF
--- a/tests/strategies/test_tagged_unions.py
+++ b/tests/strategies/test_tagged_unions.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Sequence, Union
 
 from attrs import define
 
@@ -138,3 +138,15 @@ def test_forbid_extra_keys_default():
 
     data = c.unstructure(A(), Union[A, B])
     c.structure(data, Union[A, B])
+
+
+def test_nested_sequence_union():
+    @define
+    class Top:
+        u: Optional[Sequence[Union[A, B]]]
+
+    c = Converter()
+    configure_tagged_union(Union[A, B], c)
+
+    data = c.unstructure(Top(u=[B(a="")]), Top)
+    c.structure(data, Top)


### PR DESCRIPTION
I've converted some project which uses cattrs from attrs to dataclasses, but that failed because the union dismbiguator doesn't support dataclasses yet (https://github.com/python-attrs/cattrs/issues/426#issuecomment-1731787790). So I used the opportunity to convert the code to the new tagged union strategy which is much nicer than the disambiguation stuff anyway. One case looks like the test added in this PR, which failed too (cattrs  v23.1.2). Looking into it I saw that the problem has been fixed in main by commit b25a25800f245d4504f8d9aaaa90faeca3e4adbb. So I'm awaiting a new release, but in the meantime thought this regression test might be helpful.