### PR TITLE
Import typing_extensions.TypeAlias only on python < 3.11

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,9 @@
 # History
+
 ## 23.2.1 (UNRELEASED)
 
 - Fix unnecessary `typing_extensions` import on Python 3.11.
-  ([#446](https://github.com/python-attrs/cattrs/issues/446))
+  ([#446](https://github.com/python-attrs/cattrs/issues/446) [#447](https://github.com/python-attrs/cattrs/pull/447))
 
 ## 23.2.0 (2023-11-17)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
 # History
+## 23.2.1 (UNRELEASED)
+
+- Fix unnecessary `typing_extensions` import on Python 3.11.
+  ([#446](https://github.com/python-attrs/cattrs/issues/446))
 
 ## 23.2.0 (2023-11-17)
 

--- a/src/cattrs/_compat.py
+++ b/src/cattrs/_compat.py
@@ -20,7 +20,13 @@ from attrs import NOTHING, Attribute, Factory
 from attrs import fields as attrs_fields
 from attrs import resolve_types
 
-__all__ = ["ExceptionGroup", "ExtensionsTypedDict", "TypedDict", "is_typeddict"]
+__all__ = [
+    "ExceptionGroup",
+    "ExtensionsTypedDict",
+    "TypedDict",
+    "TypeAlias",
+    "is_typeddict",
+]
 
 try:
     from typing_extensions import TypedDict as ExtensionsTypedDict
@@ -38,6 +44,12 @@ try:
 except ImportError:
     assert sys.version_info >= (3, 10)
     from typing import is_typeddict as _is_typeddict
+
+try:
+    from typing_extensions import TypeAlias
+except ImportError:
+    assert sys.version_info >= (3, 11)
+    from typing import TypeAlias
 
 
 def is_typeddict(cls):

--- a/src/cattrs/dispatch.py
+++ b/src/cattrs/dispatch.py
@@ -2,7 +2,8 @@ from functools import lru_cache, partial, singledispatch
 from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 
 from attrs import Factory, define, field
-from typing_extensions import TypeAlias
+
+from cattrs._compat import TypeAlias
 
 T = TypeVar("T")
 


### PR DESCRIPTION
Fixes #446 