### PR TITLE
build(deps): remove python version constraint for `typing_extensions`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ authors = [
 ]
 dependencies = [
     "attrs>=23.1.0",
-    "typing-extensions>=4.1.0, !=4.6.3; python_version < '3.11'",
+    "typing-extensions>=4.1.0, !=4.6.3",
     "exceptiongroup>=1.1.1; python_version < '3.11'",
 ]
 requires-python = ">=3.8"


### PR DESCRIPTION
With latest release, v23.2.0, there is a module import error with typing_extensions. This occurs when using Python 3.11, which is currently excluded from using the dependency.

```txt
    File "/home/runner/work/_actions/LizardByte/plexhints/v0.1.3/venv/lib/python3.11/site-packages/requests_cache/__init__.py", line 7, in <module>
      from .backends import *
    File "/home/runner/work/_actions/LizardByte/plexhints/v0.1.3/venv/lib/python3.11/site-packages/requests_cache/backends/__init__.py", line 7, in <module>
      from .base import BaseCache, BaseStorage, DictStorage
    File "/home/runner/work/_actions/LizardByte/plexhints/v0.1.3/venv/lib/python3.11/site-packages/requests_cache/backends/base.py", line 22, in <module>
      from ..serializers import SerializerType, init_serializer
    File "/home/runner/work/_actions/LizardByte/plexhints/v0.1.3/venv/lib/python3.11/site-packages/requests_cache/serializers/__init__.py", line 24, in <module>
      from .cattrs import CattrStage
    File "/home/runner/work/_actions/LizardByte/plexhints/v0.1.3/venv/lib/python3.11/site-packages/requests_cache/serializers/cattrs.py", line 19, in <module>
      from cattr import Converter
    File "/home/runner/work/_actions/LizardByte/plexhints/v0.1.3/venv/lib/python3.11/site-packages/cattr/__init__.py", line 1, in <module>
      from .converters import BaseConverter, Converter, GenConverter, UnstructureStrategy
    File "/home/runner/work/_actions/LizardByte/plexhints/v0.1.3/venv/lib/python3.11/site-packages/cattr/converters.py", line 1, in <module>
      from cattrs.converters import (
    File "/home/runner/work/_actions/LizardByte/plexhints/v0.1.3/venv/lib/python3.11/site-packages/cattrs/__init__.py", line 1, in <module>
      from .converters import BaseConverter, Converter, GenConverter, UnstructureStrategy
    File "/home/runner/work/_actions/LizardByte/plexhints/v0.1.3/venv/lib/python3.11/site-packages/cattrs/converters.py", line 58, in <module>
      from .dispatch import HookFactory, MultiStrategyDispatch, StructureHook, UnstructureHook
    File "/home/runner/work/_actions/LizardByte/plexhints/v0.1.3/venv/lib/python3.11/site-packages/cattrs/dispatch.py", line 5, in <module>
      from typing_extensions import TypeAlias
  ModuleNotFoundError: No module named 'typing_extensions'
```