### PR TITLE
Avoid linecache unique file generation in case of linecache disabled

### DIFF
--- a/src/cattrs/gen/__init__.py
+++ b/src/cattrs/gen/__init__.py
@@ -212,22 +212,20 @@ def make_dict_unstructure_fn(
             + ["  return res"]
         )
         script = "\n".join(total_lines)
-
-        fname = generate_unique_filename(
-            cl, "unstructure", reserve=_cattrs_use_linecache
-        )
-
-        eval(compile(script, fname, "exec"), globs)
-
-        fn = globs[fn_name]
+        fname = ""
         if _cattrs_use_linecache:
+            fname = generate_unique_filename(
+                cl, "unstructure", reserve=_cattrs_use_linecache
+            )
             linecache.cache[fname] = len(script), None, total_lines, fname
+
+        eval(compile(script, fname "exec"), globs)
     finally:
         working_set.remove(cl)
         if not working_set:
             del already_generating.working_set
 
-    return fn
+    return globs[fn_name]
 
 
 DictStructureFn = Callable[[Mapping[str, Any], Any], T]
@@ -628,11 +626,13 @@ def make_dict_structure_fn(
         *pi_lines,
     ]
 
-    fname = generate_unique_filename(cl, "structure", reserve=_cattrs_use_linecache)
     script = "\n".join(total_lines)
-    eval(compile(script, fname, "exec"), globs)
+    fname = ""
     if _cattrs_use_linecache:
+        fname = generate_unique_filename(cl, "structure", reserve=_cattrs_use_linecache)
         linecache.cache[fname] = len(script), None, total_lines, fname
+
+    eval(compile(script, fname , "exec"), globs)
 
     return globs[fn_name]
 

--- a/src/cattrs/gen/typeddicts.py
+++ b/src/cattrs/gen/typeddicts.py
@@ -225,21 +225,20 @@ def make_dict_unstructure_fn(
         ]
         script = "\n".join(total_lines)
 
-        fname = generate_unique_filename(
-            cl, "unstructure", reserve=_cattrs_use_linecache
-        )
+        fname = ""
+        if _cattrs_use_linecache:
+            fname = generate_unique_filename(
+                cl, "unstructure", reserve=_cattrs_use_linecache
+            )
+            linecache.cache[fname] = len(script), None, total_lines, fname
 
         eval(compile(script, fname, "exec"), globs)
-
-        fn = globs[fn_name]
-        if _cattrs_use_linecache:
-            linecache.cache[fname] = len(script), None, total_lines, fname
     finally:
         working_set.remove(cl)
         if not working_set:
             del already_generating.working_set
 
-    return fn
+    return globs[fn_name]
 
 
 def make_dict_structure_fn(
@@ -523,12 +522,13 @@ def make_dict_structure_fn(
         "  return res",
     ]
 
-    fname = generate_unique_filename(cl, "structure", reserve=_cattrs_use_linecache)
     script = "\n".join(total_lines)
-    eval(compile(script, fname, "exec"), globs)
+    fname = ""
     if _cattrs_use_linecache:
+        fname = generate_unique_filename(cl, "structure", reserve=_cattrs_use_linecache)
         linecache.cache[fname] = len(script), None, total_lines, fname
 
+    eval(compile(script, fname, "exec"), globs)
     return globs[fn_name]
 
 


### PR DESCRIPTION
When cattrs' converter/hooks or same classes are created too frequent or in large amount, `generate_unique_filename` (generation of unique file with uuid) becomes slow/inefficient even if `linecache` flag is disabled.
This PR executes this function only when cache is enabled. More optimisation can be done for compilation of same classes repeatably, as mentioned in below issue.
Issue discussion: https://github.com/python-attrs/cattrs/issues/445