### PR TITLE
structure typing_extension.Literal to support old code

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,8 @@
   ([#463](https://github.com/python-attrs/cattrs/pull/463))
 - More robust support for `Annotated` and `NotRequired` in TypedDicts.
   ([#450](https://github.com/python-attrs/cattrs/pull/450))
+- `typing_extensions.Literal` is now automatically structured, just like `typing.Literal`.
+  ([#460](https://github.com/python-attrs/cattrs/issues/460) [#467](https://github.com/python-attrs/cattrs/pull/467))
 - [PEP 695](https://peps.python.org/pep-0695/) generics are now tested.
   ([#452](https://github.com/python-attrs/cattrs/pull/452))
 - Imports are now sorted using Ruff.

--- a/src/cattrs/_compat.py
+++ b/src/cattrs/_compat.py
@@ -48,7 +48,6 @@ try:
 except ImportError:  # pragma: no cover
     ExtensionsTypedDict = None
 
-
 if sys.version_info >= (3, 11):
     from builtins import ExceptionGroup
 else:
@@ -65,6 +64,14 @@ try:
 except ImportError:  # pragma: no cover
     assert sys.version_info >= (3, 11)
     from typing import TypeAlias
+
+LITERALS = {Literal}
+try:
+    from typing_extensions import Literal as teLiteral
+
+    LITERALS.add(teLiteral)
+except ImportError:  # pragma: no cover
+    pass
 
 
 def is_typeddict(cls):
@@ -203,7 +210,12 @@ if sys.version_info >= (3, 9):
         from typing import _LiteralGenericAlias
 
         def is_literal(type) -> bool:
-            return type.__class__ is _LiteralGenericAlias
+            return type in LITERALS or (
+                isinstance(
+                    type, (_GenericAlias, _LiteralGenericAlias, _SpecialGenericAlias)
+                )
+                and type.__origin__ in LITERALS
+            )
 
     except ImportError:  # pragma: no cover
 
@@ -479,7 +491,9 @@ else:
         )
 
     def is_literal(type) -> bool:
-        return type.__class__ is _GenericAlias and type.__origin__ is Literal
+        return type in LITERALS or (
+            isinstance(type, _GenericAlias) and type.__origin__ in LITERALS
+        )
 
     def is_generic(obj):
         return isinstance(obj, _GenericAlias) or (

--- a/tests/test_structure_attrs.py
+++ b/tests/test_structure_attrs.py
@@ -151,6 +151,21 @@ def test_structure_literal(converter_cls):
 
 
 @pytest.mark.parametrize("converter_cls", [BaseConverter, Converter])
+def test_structure_typing_extensions_literal(converter_cls):
+    """Structuring a class with a typing_extensions.Literal field works."""
+    converter = converter_cls()
+    import typing_extensions
+
+    @define
+    class ClassWithLiteral:
+        literal_field: typing_extensions.Literal[8] = 8
+
+    assert converter.structure(
+        {"literal_field": 8}, ClassWithLiteral
+    ) == ClassWithLiteral(8)
+
+
+@pytest.mark.parametrize("converter_cls", [BaseConverter, Converter])
 def test_structure_literal_enum(converter_cls):
     """Structuring a class with a literal field works."""
     converter = converter_cls()


### PR DESCRIPTION
...or libraries that still support Python 3.7

would close #460 