### PR TITLE
Don't install `msgspec` on PyPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ bson = [
     "pymongo>=4.4.0",
 ]
 msgspec = [
-    "msgspec>=0.18.5",
+    "msgspec>=0.18.5; implementation_name == \"cpython\"",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
`msgspec` is [only supported on CPython](https://github.com/jcrist/msgspec/issues/22#issuecomment-1349049009). This creates an issue when installing with: `pdm install -G :all`.