### PR TITLE
Add cattrs support for TypeVar with default (PEP696)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -33,6 +33,8 @@ can now be used as decorators and have gained new features.
   ([#426](https://github.com/python-attrs/cattrs/issues/426) [#477](https://github.com/python-attrs/cattrs/pull/477))
 - Add support for [PEP 695](https://peps.python.org/pep-0695/) type aliases.
   ([#452](https://github.com/python-attrs/cattrs/pull/452))
+- Add support for [PEP 696](https://peps.python.org/pep-0696/) `TypeVar`s with defaults.
+  ([#512](https://github.com/python-attrs/cattrs/pull/512))
 - Add support for named tuples with type metadata ([`typing.NamedTuple`](https://docs.python.org/3/library/typing.html#typing.NamedTuple)).
   ([#425](https://github.com/python-attrs/cattrs/issues/425) [#491](https://github.com/python-attrs/cattrs/pull/491))
 - The `include_subclasses` strategy now fetches the member hooks from the converter (making use of converter defaults) if overrides are not provided, instead of generating new hooks with no overrides.

--- a/tests/test_generics_696.py
+++ b/tests/test_generics_696.py
@@ -1,0 +1,50 @@
++"""Tests for generics under PEP 696 (type defaults)."""
+from typing import Generic
+
+import pytest
+from attrs import define, fields
+from typing_extensions import TypeVar
+
+from cattrs.errors import StructureHandlerNotFoundError
+from cattrs.gen import generate_mapping
+
+T = TypeVar("T")
+TD = TypeVar("TD", default=str)
+
+
+def test_structure_typevar_default(genconverter):
+    """Generics with defaulted TypeVars work."""
+
+    @define
+    class C(Generic[T]):
+        a: T
+
+    c_mapping = generate_mapping(C)
+    atype = fields(C).a.type
+    assert atype.__name__ not in c_mapping
+
+    with pytest.raises(StructureHandlerNotFoundError):
+        # Missing type for generic argument
+        genconverter.structure({"a": "1"}, C)
+
+    c_mapping = generate_mapping(C[str])
+    atype = fields(C[str]).a.type
+    assert c_mapping[atype.__name__] == str
+
+    assert genconverter.structure({"a": "1"}, C[str]) == C("1")
+
+    @define
+    class D(Generic[TD]):
+        a: TD
+
+    d_mapping = generate_mapping(D)
+    atype = fields(D).a.type
+    assert d_mapping[atype.__name__] == str
+
+    # Defaults to string
+    assert d_mapping[atype.__name__] == str
+    assert genconverter.structure({"a": "1"}, D) == D("1")
+
+    # But allows other types
+    assert genconverter.structure({"a": "1"}, D[str]) == D("1")
+    assert genconverter.structure({"a": 1}, D[int]) == D(1)

--- a/tests/test_generics_696.py
+++ b/tests/test_generics_696.py
@@ -1,4 +1,4 @@
-+"""Tests for generics under PEP 696 (type defaults)."""
+"""Tests for generics under PEP 696 (type defaults)."""
 from typing import Generic
 
 import pytest


### PR DESCRIPTION
# Purpose
This adds support for TypeVars with default values, as defined in [PEP 696](https://peps.python.org/pep-0696/).  This PEP was [recently recommended by the typing council to be accepted](https://github.com/python/typing-council/issues/12#issuecomment-1935231468), and is currently [already available](https://github.com/python/typing_extensions/blob/06b23e3f05fd0f929dbaea17ae51621dcc8434ab/src/typing_extensions.py#L1435-L1443) via `typing_extensions.TypeVar` (see test case)

# Background
Essentially if you have a generic class:

```python
from attrs import define
from typing import TypeVar

T = TypeVar("T")

@define
class C(Generic[T]):
    a: T
```

You must specify the generic type to use it:

```python
@define
class Foo:
    c: C[str]  # C.a = str
```

While this causes is [an error](https://github.com/jason-myers-klaviyo/cattrs/blob/93d0e9dc29dc60ccf504c54494a3ece29f42ac03/src/cattrs/gen/__init__.py#L318) when structuring (as expected):


```python
@define
class Foo:
    c: C  # C.a = ?
```

Since we don't know what type to use for `T` in `C`

# Change

PEP 696 allows you to set a default type that is used if the generic type is not specified, so this becomes possible:

```python
from attrs import define
from typing_extensions import TypeVar

T = TypeVar("T", default=str)  # This part is new

@define
class C(Generic[T]):
    a: T
```

And you can now use `C` directly without specifying a type, and the type will be defaulted:

```python
@define
class Foo:
    c: C  # C.a = str

@define
class Bar:
    c: C[int]  # C.a = int
```
