### PR TITLE
WIP: Expand docs on unstructuring

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -72,7 +72,7 @@ This new hook can be used directly or registered to a converter (the original in
 ```
 
 
-Now if we use this hook to structure a `Model`, through ✨the magic of function composition✨ that hook will use our old `int_hook`.
+Now if we use this hook to structure a `Model`, through ✨the magic of function composition✨ that hook will use the pre-existing (default) `Model` hook, which takes advanatge of our `int_hook`.
 
 ```python
 >>> converter.structure({"a": "1"}, Model)

--- a/src/cattrs/converters.py
+++ b/src/cattrs/converters.py
@@ -272,6 +272,14 @@ class BaseConverter:
         self._struct_copy_skip = self._structure_func.get_num_fns()
 
     def unstructure(self, obj: Any, unstructure_as: Any = None) -> Any:
+        """Unstructure an object.
+
+        :param obj: The object to unstructure.
+        :param unstructure_as: The type to unstructure as. If not provided, the
+            type of the object (``obj.__class__``) will be used. Using ``unstructure_as``
+            can allow specification of generics, for example to ensure that ``list[A]``
+            is unstructured as ``list[A]`` rather than as ``list``.
+        """
         return self._unstructure_func.dispatch(
             obj.__class__ if unstructure_as is None else unstructure_as
         )(obj)


### PR DESCRIPTION
I ran into some confusing situations trying to unstructure some objects I had defined (#513 ) and it was suggested I create a PR clarifying the docs. This PR attempts to do this.

I should say, my understanding of how `cattrs` works, and of how `cattrs` is meant to be used, is a little shaky, so feedback on this documentation is highly welcome.

I am also totally new to `cattrs` development, so I'm not sure where anything goes. In particular, is there a place for demo code that will be executed? Should I add tests to verify that the behaviour I am describing in the docs is really what happens? I'm not sure how to run the doctests, particularly in the `docs/` directory.