### PR TITLE
Make detection of TypeVar defaults robust to the CPython PEP-696 implementation

### DIFF
--- a/src/cattrs/gen/_generics.py
+++ b/src/cattrs/gen/_generics.py
@@ -5,6 +5,30 @@ from typing import TypeVar
 from .._compat import get_args, get_origin, is_generic
 
 
+def _tvar_has_default(tvar) -> bool:
+    """Does `tvar` have a default?
+
+    In CPython 3.13+ and typing_extensions>=4.12.0:
+    - TypeVars have a `no_default()` method for detecting
+      if a TypeVar has a default
+    - TypeVars with `default=None` have `__default__` set to `None`
+    - TypeVars with no `default` parameter passed
+      have `__default__` set to `typing(_extensions).NoDefault
+
+    On typing_exensions<4.12.0:
+    - TypeVars do not have a `no_default()` method for detecting
+      if a TypeVar has a default
+    - TypeVars with `default=None` have `__default__` set to `NoneType`
+    - TypeVars with no `default` parameter passed
+      have `__default__` set to `typing(_extensions).NoDefault
+    """
+    try:
+        return tvar.has_default()
+    except AttributeError:
+        # compatibility for typing_extensions<4.12.0
+        return getattr(tvar, "__default__", None) is not None
+
+
 def generate_mapping(cl: type, old_mapping: dict[str, type] = {}) -> dict[str, type]:
     """Generate a mapping of typevars to actual types for a generic class."""
     mapping = dict(old_mapping)
@@ -35,10 +59,7 @@ def generate_mapping(cl: type, old_mapping: dict[str, type] = {}) -> dict[str, t
             base_args = base.__args__
             if hasattr(base.__origin__, "__parameters__"):
                 base_params = base.__origin__.__parameters__
-            elif any(
-                getattr(base_arg, "__default__", None) is not None
-                for base_arg in base_args
-            ):
+            elif any(_tvar_has_default(base_arg) for base_arg in base_args):
                 # TypeVar with a default e.g. PEP 696
                 # https://www.python.org/dev/peps/pep-0696/
                 # Extract the defaults for the TypeVars and insert
@@ -46,9 +67,7 @@ def generate_mapping(cl: type, old_mapping: dict[str, type] = {}) -> dict[str, t
                 mapping_params = [
                     (base_arg, base_arg.__default__)
                     for base_arg in base_args
-                    # Note: None means no default was provided, since
-                    # TypeVar("T", default=None) sets NoneType as the default
-                    if getattr(base_arg, "__default__", None) is not None
+                    if _tvar_has_default(base_arg)
                 ]
                 base_params, base_args = zip(*mapping_params)
             else:


### PR DESCRIPTION
When implementing PEP 696 (default values for TypeVars, ParamSpecs and TypeVarTuples, we decided to implement the PEP slightly differently from the prototype that existed in `typing_extensions`. Specifically:
- With the old implementation in `typing_extensions`:
  - If you passed `default=None` when constructing a TypeVar, the `__default__` attribute would be set to `types.NoneType`
  - If you did not pass a value to the `default=` parameter, the `__default__` attribute would be set to `None`
- With the new implementation in CPython:
  - If you pass `default=None` when constructing a TypeVar, the `__default__` attribute is set to `None`
  - If you do not pass a value to the `default=` parameter, the `__default__` attribute is set to the new sentinel object `typing.NoDefault`.
- The new implementation at CPython also has added a new `has_default()` method to TypeVars, ParamSpecs and TypeVarTuples

I backported these changes to the `typing_extensions` implementation of PEP 696 yesterday, and we realised today that it breaks some tests over at cattrs: https://github.com/python/typing_extensions/issues/381. This PR fixes the tests so that they work if you're using a released version of `typing_extensions`, but they also work with the CPython implementation of PEP 696 and with the `typing_extensions` main branch.

I tested the PR locally by making this change to `pyproject.toml`:

```diff
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ authors = [
 ]
 dependencies = [
     "attrs>=23.1.0",
-    "typing-extensions>=4.1.0, !=4.6.3; python_version < '3.11'",
+    "typing-extensions @ git+https://github.com/python/typing_extensions.git",
     "exceptiongroup>=1.1.1; python_version < '3.11'",
 ]
 requires-python = ">=3.8"
@@ -148,6 +148,9 @@ ignore = [
     "DTZ006", # datetimes in tests
 ]
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.version]
```

And then re-running `pdm install -d -G :all` and `tox`. The tests all passed.

I didn't add an entry to `HISTORY.md`, as it looks like cattrs's PEP-696 support is unreleased right now (so it's a bugfix for an unreleased feature)!