### PR TITLE
fix: wrong return type

### DIFF
--- a/src/cattrs/converters.py
+++ b/src/cattrs/converters.py
@@ -1214,7 +1214,7 @@ class Converter(BaseConverter):
 
         return unstructure_optional
 
-    def gen_structure_typeddict(self, cl: Any) -> Callable[[dict], dict]:
+    def gen_structure_typeddict(self, cl: Any) -> Callable[[dict, Any], dict]:
         """Generate a TypedDict structure function.
 
         Also apply converter-scored modifications.


### PR DESCRIPTION
Fixes the return type to be consistent with the underlying call:

https://github.com/python-attrs/cattrs/blob/5fd0f5b445928064338e6fcdac081e608b51e541/src/cattrs/gen/typeddicts.py#L239-L246