### PR TITLE
Converter parameter type hints

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,6 +22,7 @@ Our backwards-compatibility policy can be found [here](https://github.com/python
 - Python 3.13 is now supported.
   ([#543](https://github.com/python-attrs/cattrs/pull/543) [#547](https://github.com/python-attrs/cattrs/issues/547))
 - Python 3.8 is no longer supported, as it is end-of-life. Use previous versions on this Python version.
+- Change type of Converter.__init__.unstruct_collection_overrides from Callable to Mapping[type, UnstructureHook] ([#594](https://github.com/python-attrs/cattrs/pull/594).
 
 ## 24.1.2 (2024-09-22)
 

--- a/src/cattrs/converters.py
+++ b/src/cattrs/converters.py
@@ -1046,7 +1046,7 @@ class Converter(BaseConverter):
         omit_if_default: bool = False,
         forbid_extra_keys: bool = False,
         type_overrides: Mapping[type, AttributeOverride] = {},
-        unstruct_collection_overrides: Mapping[type, UnstructureHookT] = {},
+        unstruct_collection_overrides: Mapping[type, UnstructureHook] = {},
         prefer_attrib_converters: bool = False,
         detailed_validation: bool = True,
         unstructure_fallback_factory: HookFactory[UnstructureHook] = lambda _: identity,


### PR DESCRIPTION
Change type of unstruct_collection_overrides from Mapping[type, Callable] to Mapping[type, UnstructureHookT] in Converter.__init__.