### PR TITLE
Support generic parents in include_subclasses strategy

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -46,6 +46,8 @@ Our backwards-compatibility policy can be found [here](https://github.com/python
   ([#599](https://github.com/python-attrs/cattrs/pull/599))
 - Structuring TypedDicts from invalid inputs now properly raises a {class}`ClassValidationError`.
   ([#615](https://github.com/python-attrs/cattrs/issues/615) [#616](https://github.com/python-attrs/cattrs/pull/616))
+- {func} `cattrs.strategies.include_subclasses` now properly working with generic parent classes.
+  ([#649](https://github.com/python-attrs/cattrs/pull/650))
 - Replace `cattrs.gen.MappingStructureFn` with {class}`cattrs.SimpleStructureHook`.
 - Python 3.13 is now supported.
   ([#543](https://github.com/python-attrs/cattrs/pull/543) [#547](https://github.com/python-attrs/cattrs/issues/547))

--- a/src/cattrs/strategies/_subclasses.py
+++ b/src/cattrs/strategies/_subclasses.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import typing
 from gc import collect
 from typing import Any, Callable, TypeVar, Union
 
@@ -11,8 +12,12 @@ from ..gen._consts import already_generating
 
 
 def _make_subclasses_tree(cl: type) -> list[type]:
+    # get class origin for accessing subclasses (see #648 for more info)
+    cls_origin = typing.get_origin(cl) or cl
     return [cl] + [
-        sscl for scl in cl.__subclasses__() for sscl in _make_subclasses_tree(scl)
+        sscl
+        for scl in cls_origin.__subclasses__()
+        for sscl in _make_subclasses_tree(scl)
     ]
 
 

--- a/tests/strategies/test_include_subclasses.py
+++ b/tests/strategies/test_include_subclasses.py
@@ -9,6 +9,8 @@ from cattrs import Converter, override
 from cattrs.errors import ClassValidationError, StructureHandlerNotFoundError
 from cattrs.strategies import configure_tagged_union, include_subclasses
 
+T = typing.TypeVar("T")
+
 
 @define
 class Parent:
@@ -412,3 +414,21 @@ def test_unsupported_class(genconverter: Converter):
 
     with pytest.raises(StructureHandlerNotFoundError):
         include_subclasses(NewParent, genconverter)
+
+
+def test_parents_with_generics(genconverter: Converter):
+    """Ensure proper handling of generic parents #648."""
+
+    @define
+    class GenericParent(typing.Generic[T]):
+        p: T
+
+    @define
+    class Child1G(GenericParent[str]):
+        c: str
+
+    include_subclasses(GenericParent[str], genconverter)
+
+    assert genconverter.structure({"p": 5, "c": 5}, GenericParent[str]) == Child1G(
+        "5", "5"
+    )


### PR DESCRIPTION
Resolves #648

The strategy was using parent_cls.__subclasses__() to get the list of subclasses. In case of generics, this method is unavailable.

The fix applies sanitizing the cl and getting its origin class for getting a sublcasses tree.

The class itself remains generic in the tree.