### PR TITLE
Extract use_alias from converter by default

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,9 +11,9 @@ The third number is for emergencies when we need to start branches for older rel
 
 Our backwards-compatibility policy can be found [here](https://github.com/python-attrs/cattrs/blob/main/.github/SECURITY.md).
 
-## 25.2.0 (2025-06-24)
+## 25.2.0 (unreleased)
 
-- **Potentially breaking**: {class}`cattrs.Converter` now accepts a `use_alias` parameters. 
+- Add a `use_alias` parameter to {class}`cattrs.Converter`. 
   {py:func}`cattrs.gen.make_dict_unstructure_fn_from_attrs`, {py:func}`cattrs.gen.make_dict_unstructure_fn`,
   {py:func}`cattrs.gen.make_dict_structure_fn_from_attrs`, {py:func}`cattrs.gen.make_dict_structure_fn`
   and {py:func}`cattrs.gen.typeddicts.make_dict_structure_fn` will use the value for the `use_alias` parameter from the given converter by default now.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,9 +14,9 @@ Our backwards-compatibility policy can be found [here](https://github.com/python
 ## 25.2.0 (unreleased)
 
 - Add a `use_alias` parameter to {class}`cattrs.Converter`. 
-  {py:func}`cattrs.gen.make_dict_unstructure_fn_from_attrs`, {py:func}`cattrs.gen.make_dict_unstructure_fn`,
-  {py:func}`cattrs.gen.make_dict_structure_fn_from_attrs`, {py:func}`cattrs.gen.make_dict_structure_fn`
-  and {py:func}`cattrs.gen.typeddicts.make_dict_structure_fn` will use the value for the `use_alias` parameter from the given converter by default now.
+  {func}`cattrs.gen.make_dict_unstructure_fn_from_attrs`, {func}`cattrs.gen.make_dict_unstructure_fn`,
+  {func}`cattrs.gen.make_dict_structure_fn_from_attrs`, {func}`cattrs.gen.make_dict_structure_fn`
+  and {func}`cattrs.gen.typeddicts.make_dict_structure_fn` will use the value for the `use_alias` parameter from the given converter by default now.
   If you're using these functions directly, the old behavior can be restored by passing in the desired value directly.
   ([#596](https://github.com/python-attrs/cattrs/issues/596) [#660](https://github.com/python-attrs/cattrs/pull/660))
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,15 @@ The third number is for emergencies when we need to start branches for older rel
 
 Our backwards-compatibility policy can be found [here](https://github.com/python-attrs/cattrs/blob/main/.github/SECURITY.md).
 
+## 25.2.0 (2025-06-24)
+
+- **Potentially breaking**: {class}`cattrs.Converter` now accepts a `use_alias` parameters. 
+  {py:func}`cattrs.gen.make_dict_unstructure_fn_from_attrs`, {py:func}`cattrs.gen.make_dict_unstructure_fn`,
+  {py:func}`cattrs.gen.make_dict_structure_fn_from_attrs`, {py:func}`cattrs.gen.make_dict_structure_fn`
+  and {py:func}`cattrs.gen.typeddicts.make_dict_structure_fn` will use the value for the `use_alias` parameter from the given converter by default now.
+  If you're using these functions directly, the old behavior can be restored by passing in the desired value directly.
+  ([#596](https://github.com/python-attrs/cattrs/issues/596) [#660](https://github.com/python-attrs/cattrs/pull/660))
+
 ## 25.1.1 (2025-06-04)
 
 - Fixed `AttributeError: no attribute '__parameters__'` while structuring attrs classes that inherit from parametrized generic aliases from `collections.abc`.

--- a/src/cattrs/converters.py
+++ b/src/cattrs/converters.py
@@ -1034,6 +1034,7 @@ class Converter(BaseConverter):
         "forbid_extra_keys",
         "omit_if_default",
         "type_overrides",
+        "use_alias",
     )
 
     def __init__(
@@ -1050,6 +1051,7 @@ class Converter(BaseConverter):
         structure_fallback_factory: HookFactory[StructureHook] = lambda t: raise_error(
             None, t
         ),
+        use_alias: bool = False,
     ):
         """
         :param detailed_validation: Whether to use a slightly slower mode for detailed
@@ -1064,6 +1066,7 @@ class Converter(BaseConverter):
         ..  versionchanged:: 24.2.0
             The default `structure_fallback_factory` now raises errors for missing handlers
             more eagerly, surfacing problems earlier.
+        ..  versionadded:: 25.2.0 *use_alias*
         """
         super().__init__(
             dict_factory=dict_factory,
@@ -1076,6 +1079,7 @@ class Converter(BaseConverter):
         self.omit_if_default = omit_if_default
         self.forbid_extra_keys = forbid_extra_keys
         self.type_overrides = dict(type_overrides)
+        self.use_alias = use_alias
 
         unstruct_collection_overrides = {
             get_origin(k) or k: v for k, v in unstruct_collection_overrides.items()
@@ -1299,6 +1303,7 @@ class Converter(BaseConverter):
             _cattrs_forbid_extra_keys=self.forbid_extra_keys,
             _cattrs_prefer_attrib_converters=self._prefer_attrib_converters,
             _cattrs_detailed_validation=self.detailed_validation,
+            _cattrs_use_alias=self.use_alias,
             **attrib_overrides,
         )
 
@@ -1377,6 +1382,7 @@ class Converter(BaseConverter):
         unstruct_collection_overrides: Mapping[type, UnstructureHook] | None = None,
         prefer_attrib_converters: bool | None = None,
         detailed_validation: bool | None = None,
+        use_alias: bool | None = None,
     ) -> Self:
         """Create a copy of the converter, keeping all existing custom hooks.
 
@@ -1416,6 +1422,7 @@ class Converter(BaseConverter):
                 if detailed_validation is not None
                 else self.detailed_validation
             ),
+            use_alias=(use_alias if use_alias is not None else self.use_alias),
         )
 
         self._unstructure_func.copy_to(

--- a/src/cattrs/converters.py
+++ b/src/cattrs/converters.py
@@ -1060,6 +1060,8 @@ class Converter(BaseConverter):
             registered unstructuring hooks match.
         :param structure_fallback_factory: A hook factory to be called when no
             registered structuring hooks match.
+        :param use_alias: Whether to use the field alias instead of the field name as
+            the un/structured dictionary key by default.
 
         ..  versionadded:: 23.2.0 *unstructure_fallback_factory*
         ..  versionadded:: 23.2.0 *structure_fallback_factory*

--- a/src/cattrs/gen/__init__.py
+++ b/src/cattrs/gen/__init__.py
@@ -217,7 +217,7 @@ def make_dict_unstructure_fn(
     converter: BaseConverter,
     _cattrs_omit_if_default: bool = False,
     _cattrs_use_linecache: bool = True,
-    _cattrs_use_alias: bool = False,
+    _cattrs_use_alias: bool | Literal["from_converter"] = "from_converter",
     _cattrs_include_init_false: bool = False,
     **kwargs: AttributeOverride,
 ) -> Callable[[T], dict[str, Any]]:
@@ -237,11 +237,17 @@ def make_dict_unstructure_fn(
 
     ..  versionadded:: 23.2.0 *_cattrs_use_alias*
     ..  versionadded:: 23.2.0 *_cattrs_include_init_false*
+    ..  versionchanged:: 25.2.0
+        The `_cattrs_use_alias` parameter takes its value from the given converter
+        by default.
     """
     origin = get_origin(cl)
     attrs = adapted_fields(origin or cl)  # type: ignore
 
     mapping = {}
+    if _cattrs_use_alias == "from_converter":
+        # BaseConverter doesn't have it so we're careful.
+        _cattrs_use_alias = getattr(converter, "use_alias", False)
     if is_generic(cl):
         mapping = generate_mapping(cl, mapping)
 
@@ -289,7 +295,7 @@ def make_dict_structure_fn_from_attrs(
         bool | Literal["from_converter"]
     ) = "from_converter",
     _cattrs_detailed_validation: bool | Literal["from_converter"] = "from_converter",
-    _cattrs_use_alias: bool = False,
+    _cattrs_use_alias: bool | Literal["from_converter"] = "from_converter",
     _cattrs_include_init_false: bool = False,
     **kwargs: AttributeOverride,
 ) -> SimpleStructureHook[Mapping[str, Any], T]:
@@ -315,6 +321,9 @@ def make_dict_structure_fn_from_attrs(
         will be included.
 
     ..  versionadded:: 24.1.0
+    ..  versionchanged:: 25.2.0
+        The `_cattrs_use_alias` parameter takes its value from the given converter
+        by default.
     """
 
     cl_name = cl.__name__
@@ -350,6 +359,9 @@ def make_dict_structure_fn_from_attrs(
     if _cattrs_forbid_extra_keys == "from_converter":
         # BaseConverter doesn't have it so we're careful.
         _cattrs_forbid_extra_keys = getattr(converter, "forbid_extra_keys", False)
+    if _cattrs_use_alias == "from_converter":
+        # BaseConverter doesn't have it so we're careful.
+        _cattrs_use_alias = getattr(converter, "use_alias", False)
     if _cattrs_detailed_validation == "from_converter":
         _cattrs_detailed_validation = converter.detailed_validation
     if _cattrs_prefer_attrib_converters == "from_converter":

--- a/src/cattrs/gen/__init__.py
+++ b/src/cattrs/gen/__init__.py
@@ -694,7 +694,7 @@ def make_dict_structure_fn(
         bool | Literal["from_converter"]
     ) = "from_converter",
     _cattrs_detailed_validation: bool | Literal["from_converter"] = "from_converter",
-    _cattrs_use_alias: bool = False,
+    _cattrs_use_alias: bool | Literal["from_converter"] = "from_converter",
     _cattrs_include_init_false: bool = False,
     **kwargs: AttributeOverride,
 ) -> SimpleStructureHook[Mapping[str, Any], T]:
@@ -726,6 +726,9 @@ def make_dict_structure_fn(
     ..  versionchanged:: 24.1.0
         The `_cattrs_prefer_attrib_converters` parameter takes its value from the given
         converter by default.
+    ..  versionchanged:: 25.2.0
+        The `_cattrs_use_alias` parameter takes its value from the given converter
+        by default.
     """
 
     mapping = {}

--- a/src/cattrs/gen/__init__.py
+++ b/src/cattrs/gen/__init__.py
@@ -74,7 +74,7 @@ def make_dict_unstructure_fn_from_attrs(
     typevar_map: dict[str, Any] = {},
     _cattrs_omit_if_default: bool = False,
     _cattrs_use_linecache: bool = True,
-    _cattrs_use_alias: bool = False,
+    _cattrs_use_alias: bool | Literal["from_converter"] = "from_converter",
     _cattrs_include_init_false: bool = False,
     **kwargs: AttributeOverride,
 ) -> Callable[[T], dict[str, Any]]:
@@ -96,6 +96,9 @@ def make_dict_unstructure_fn_from_attrs(
         will be included.
 
     ..  versionadded:: 24.1.0
+    ..  versionchanged:: 25.2.0
+        The `_cattrs_use_alias` parameter takes its value from the given converter
+        by default.
     """
 
     fn_name = "unstructure_" + cl.__name__
@@ -103,6 +106,10 @@ def make_dict_unstructure_fn_from_attrs(
     lines = []
     invocation_lines = []
     internal_arg_parts = {}
+
+    if _cattrs_use_alias == "from_converter":
+        # BaseConverter doesn't have it so we're careful.
+        _cattrs_use_alias = getattr(converter, "use_alias", False)
 
     for a in attrs:
         attr_name = a.name

--- a/src/cattrs/gen/typeddicts.py
+++ b/src/cattrs/gen/typeddicts.py
@@ -234,7 +234,6 @@ def make_dict_structure_fn(
     _cattrs_forbid_extra_keys: bool | Literal["from_converter"] = "from_converter",
     _cattrs_use_linecache: bool = True,
     _cattrs_detailed_validation: bool | Literal["from_converter"] = "from_converter",
-    _cattrs_use_alias: bool | Literal["from_converter"] = "from_converter",
     **kwargs: AttributeOverride,
 ) -> Callable[[dict, Any], Any]:
     """Generate a specialized dict structuring function for typed dicts.
@@ -253,9 +252,6 @@ def make_dict_structure_fn(
     ..  versionchanged:: 23.2.0
         The `_cattrs_forbid_extra_keys` and `_cattrs_detailed_validation` parameters
         take their values from the given converter by default.
-    ..  versionchanged:: 25.2.0
-        The `_cattrs_use_alias` parameter takes its value from the given converter
-        by default.
     """
 
     mapping = {}
@@ -304,9 +300,6 @@ def make_dict_structure_fn(
     if _cattrs_forbid_extra_keys == "from_converter":
         # BaseConverter doesn't have it so we're careful.
         _cattrs_forbid_extra_keys = getattr(converter, "forbid_extra_keys", False)
-    if _cattrs_use_alias == "from_converter":
-        # BaseConverter doesn't have it so we're careful.
-        _cattrs_use_alias = getattr(converter, "use_alias", False)
     if _cattrs_detailed_validation == "from_converter":
         _cattrs_detailed_validation = converter.detailed_validation
 

--- a/src/cattrs/gen/typeddicts.py
+++ b/src/cattrs/gen/typeddicts.py
@@ -234,6 +234,7 @@ def make_dict_structure_fn(
     _cattrs_forbid_extra_keys: bool | Literal["from_converter"] = "from_converter",
     _cattrs_use_linecache: bool = True,
     _cattrs_detailed_validation: bool | Literal["from_converter"] = "from_converter",
+    _cattrs_use_alias: bool | Literal["from_converter"] = "from_converter",
     **kwargs: AttributeOverride,
 ) -> Callable[[dict, Any], Any]:
     """Generate a specialized dict structuring function for typed dicts.
@@ -252,6 +253,9 @@ def make_dict_structure_fn(
     ..  versionchanged:: 23.2.0
         The `_cattrs_forbid_extra_keys` and `_cattrs_detailed_validation` parameters
         take their values from the given converter by default.
+    ..  versionchanged:: 25.2.0
+        The `_cattrs_use_alias` parameter takes its value from the given converter
+        by default.
     """
 
     mapping = {}
@@ -300,6 +304,9 @@ def make_dict_structure_fn(
     if _cattrs_forbid_extra_keys == "from_converter":
         # BaseConverter doesn't have it so we're careful.
         _cattrs_forbid_extra_keys = getattr(converter, "forbid_extra_keys", False)
+    if _cattrs_use_alias == "from_converter":
+        # BaseConverter doesn't have it so we're careful.
+        _cattrs_use_alias = getattr(converter, "use_alias", False)
     if _cattrs_detailed_validation == "from_converter":
         _cattrs_detailed_validation = converter.detailed_validation
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -146,6 +146,25 @@ def test_forbid_extra_keys(cls_and_vals):
     assert cve.value.exceptions[0].extra_fields == {bad_key}
 
 
+@given(cls_and_vals=simple_typed_classes())
+@pytest.mark.parametrize("use_alias", [True, False])
+def test_use_alias(cls_and_vals, use_alias):
+    """
+    (Un)structuring with use_alias=True generates/uses aliased keys.
+    """
+    converter = Converter(use_alias=use_alias)
+    cl, vals, kwargs = cls_and_vals
+    flds = fields(cl)
+    inst = cl(*vals, **kwargs)
+    unstructured = converter.unstructure(inst)
+    for fld in flds:
+        if use_alias:
+            assert fld.alias in unstructured
+        else:
+            assert fld.name in unstructured
+    converter.structure(unstructured, cl)
+
+
 @given(simple_typed_attrs(defaults=True))
 def test_forbid_extra_keys_defaults(attr_and_vals):
     """


### PR DESCRIPTION
Based on the discussion in #596, adds a `use_alias` argument to `Converter` (similar to `forbid_extra_keys') whose value is taken as default when structuring/unstructuring without specifying the corresponding argument to the method calls.

