### PR TITLE
DOCS: Fix version for "default structure hook fallback factory" migration

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -17,7 +17,7 @@ The old behavior can be restored by registering the `list_structure_factory` usi
 >>> converter.register_structure_hook_factory(is_sequence, list_structure_factory)
 ```
 
-## 24.2.0
+## 25.1.0
 
 ### The default structure hook fallback factory
 


### PR DESCRIPTION
The change was moved to version 25.1.0 from version 24.2.0 in #618 but the migration entry was not updated accordingly.