### PR TITLE
Do not untructure the Singleton `attrs.NOTHING` at all (identity) instead of to `1` (int) (attrs >= 22.2 problem)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,6 +28,10 @@ Our backwards-compatibility policy can be found [here](https://github.com/python
 - For {class}`cattrs.errors.StructureHandlerNotFoundError` and {class}`cattrs.errors.ForbiddenExtraKeysError` 
   correctly set {attr}`BaseException.args` in `super()` and hence make them pickable. 
   ([#666](https://github.com/python-attrs/cattrs/pull/666))
+- Do not Unstructure the faulty state {data}`attrs.NOTHING` instead of to `1` (int). The unstructure to `1` was caused
+  by a change in attrs 22.2 that {data}`attrs.NOTHING` is internally represented as an integer {class}`enum.Enum`, 
+  but as it is logically just a Singleton we apply now the identity-function on unstructuring it. 
+  ([#667](https://github.com/python-attrs/cattrs/pull/667))
 
 ## 25.1.1 (2025-06-04)
 

--- a/src/cattrs/converters.py
+++ b/src/cattrs/converters.py
@@ -11,6 +11,7 @@ from inspect import signature as inspect_signature
 from pathlib import Path
 from typing import Any, Optional, Tuple, TypeVar, overload
 
+from attr._make import _Nothing
 from attrs import Attribute, resolve_types
 from attrs import has as attrs_has
 from typing_extensions import Self
@@ -223,7 +224,7 @@ class BaseConverter:
             unstructure_fallback_factory, self
         )
         self._unstructure_func.register_cls_list(
-            [(bytes, identity), (str, identity), (Path, str)]
+            [(bytes, identity), (str, identity), (Path, str), (_Nothing, identity)]
         )
         self._unstructure_func.register_func_list(
             [

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,5 +1,6 @@
 """Tests for enums."""
 
+from attrs import NOTHING
 from hypothesis import given
 from hypothesis.strategies import data, sampled_from
 from pytest import raises
@@ -29,3 +30,17 @@ def test_enum_failure(enum):
         converter.structure("", type)
 
     assert exc_info.value.args[0] == f" not in literal {type!r}"
+
+
+def test_nothing_from_attrs():
+    """Test that `NOTHING` from attrs does not unstructure to `1` (int), but remains `NOTHING`."""
+    converter = BaseConverter()
+
+    assert (
+        converter.unstructure(NOTHING) != 1
+    ), "NOTHING should not unstructure to 1 (int)."
+    assert not isinstance(converter.unstructure(NOTHING), int)
+    assert not converter.unstructure(
+        NOTHING
+    )  # bool(NOTHING) should be False although `bool(1)` is True
+    assert converter.unstructure(NOTHING) is NOTHING

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -18,9 +18,9 @@ from cattrs.errors import (
     "err_cls, err_args",
     [
         (StructureHandlerNotFoundError, ("Structure Message", int)),
-        (ForbiddenExtraKeysError, ("Forbidden Message", int, {"foo", "bar"})),
-        (ForbiddenExtraKeysError, ("", str, {"foo", "bar"})),
-        (ForbiddenExtraKeysError, (None, list, {"foo", "bar"})),
+        (ForbiddenExtraKeysError, ("Forbidden Message", int, {"foo"})),
+        (ForbiddenExtraKeysError, ("", str, {"foo"})),
+        (ForbiddenExtraKeysError, (None, list, {"foo"})),
         (
             BaseValidationError,
             ("BaseValidation Message", [ValueError("Test BaseValidation")], int),


### PR DESCRIPTION
Since attrs >= 22.2 the `attrs.NOTHING` is not an object any more but implemented by an `enum.Enum`, [see here](https://github.com/python-attrs/attrs/blob/7b197b1335e336f4cab7257be7de94b2caa24b25/src/attr/_make.py#L61-L78).

That causes the follow up-problem, since cattrs supports unstructuring `enum.Enum`, it will unstructure it to `1` (int).

```python
>>> import cattrs
>>> import attrs
>>> conv = cattrs.Converter()
>>> conv.unstructure(attrs.NOTHING)
1
```

but this is unintended as `attrs.NOTHING`  should not represent an `int` but a special state in an attrs Attribute.

That leads to two problems.

First, `attrs` do set the value of an class attribute to `attrs.NOTHING` in some faulty states. When you now unstructure such a field with cattrs, it suddenly becomes an `1`.


Second, when you create an attrs Attribute (with `attrs.field` or type annotation) with *no default* the resulting object is an [`attrs.Attribute`](https://www.attrs.org/en/stable/api.html#attrs.Attribute) which `attrs.Attribute.default` value is set to `attrs.NOTHING`. So in that context, `attrs.NOTHING` means the attribute does not have any default value.

However, I have now situations where I compare a value of an attribute with its default (i.e. comparing it with  `attrs.Attribute.default`). And if the attribute is an int-field and by chance was set to `1` it is now suddenly equal to its default value although it is defined to have no default at all — which leads to some errors in my case.


Due to `attrs.NOTHING`’s special meaning of being a faulty state or that no default value is set, I think it is better to not unstructure it (identity as I do in this PR) instead of unstructure it to the (unexpected) int-value of `1`.