### PR TITLE
Make `ForbiddenExtraKeysError.__str__` deterministic

### DIFF
--- a/src/cattrs/errors.py
+++ b/src/cattrs/errors.py
@@ -134,5 +134,5 @@ class ForbiddenExtraKeysError(Exception):
         return (
             self.message
             or f"Extra fields in constructor for {self.cl.__name__}: "
-            f"{', '.join(self.extra_fields)}"
+            f"{', '.join(sorted(self.extra_fields))}"
         )


### PR DESCRIPTION
Fixes https://github.com/python-attrs/cattrs/issues/669. Currently the value returned by this method can differ depending on the iteration order of a set, which isn't deterministic. This causing `test_errors_pickling` to be flaky.