### PR TITLE
Added missing imports to hook factory decorator example.

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -147,8 +147,9 @@ A complex use case for hook factories is described over at [](usage.md#using-fac
 Here's an example of using an unstructure hook factory to handle unstructuring [queues](https://docs.python.org/3/library/queue.html#queue.Queue).
 
 ```{doctest}
+>>> from collections.abc import Callable
 >>> from queue import Queue
->>> from typing import Any, Callable, get_args, get_origin
+>>> from typing import Any, get_args, get_origin
 >>> from cattrs import Converter
 
 >>> c = Converter()

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -148,7 +148,7 @@ Here's an example of using an unstructure hook factory to handle unstructuring [
 
 ```{doctest}
 >>> from queue import Queue
->>> from typing import get_origin
+>>> from typing import Any, Callable, get_args, get_origin
 >>> from cattrs import Converter
 
 >>> c = Converter()


### PR DESCRIPTION
Hey @Tinche 👋 

I was just reviewing the docs, and noticed the `get_args` import missing, which I think it adds to have. I put the example in the editor and it complained about `Any` and `Callable` too (which I guess is fair). I thought I'd send in the clean up. 