### PR TITLE
Fix include_subclasses strategy with a generic parent and tagged_union

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,6 +17,8 @@ Our backwards-compatibility policy can be found [here](https://github.com/python
   ([#684](https://github.com/python-attrs/cattrs/pull/684))
 - Make some Hypothesis tests more robust.
   ([#684](https://github.com/python-attrs/cattrs/pull/684))
+- {func} `cattrs.strategies.include_subclasses` now works with generic parent classes and the tagged union strategy.
+  ([#683](https://github.com/python-attrs/cattrs/pull/683))
 
 ## 25.2.0 (2025-08-31)
 

--- a/src/cattrs/strategies/_subclasses.py
+++ b/src/cattrs/strategies/_subclasses.py
@@ -23,7 +23,8 @@ def _make_subclasses_tree(cl: type) -> list[type]:
 
 def _has_subclasses(cl: type, given_subclasses: tuple[type, ...]) -> bool:
     """Whether the given class has subclasses from `given_subclasses`."""
-    actual = set(cl.__subclasses__())
+    cls_origin = typing.get_origin(cl) or cl
+    actual = set(cls_origin.__subclasses__())
     given = set(given_subclasses)
     return bool(actual & given)
 
@@ -231,7 +232,13 @@ def _include_subclasses_with_union_strategy(
             return cls is _cl
 
         converter.register_unstructure_hook_func(cls_is_cl, unstruct_hook)
-        subclasses = tuple([c for c in union_classes if issubclass(c, cl)])
+        subclasses = tuple(
+            [
+                c
+                for c in union_classes
+                if issubclass(typing.get_origin(c) or c, typing.get_origin(cl) or cl)
+            ]
+        )
         if len(subclasses) > 1:
             u = Union[subclasses]  # type: ignore
             union_strategy(u, converter)


### PR DESCRIPTION
This extends the fix in #650 to the tagged union strategy. I reported the issue in #682.

Without this, using include_subclasses with tagged_union and a generic parent class raises the error `AttributeError: __subclasses__. Did you mean: '__subclasscheck__'?`.

Note: I don't know whether to edit `default_tag_generator` to say `return (typing.get_origin(typ) or typ).__name__`. It doesn't break any tests, but I'm not sure if there are cases where it wouldn't be appropriate, or what else ought to be changed if this is. For now I left it as a tag_generator override at the callsite, but it would be better for users not to have to pass this. Please advise.

The tests don't pass for me locally on the main branch (regardless of my change), but the failure is in a test that doesn't use these strategies and all the tests passed when I rebased my fix on 25.1.1, so I hope I'm just confused about something unrelated. (The failure is `tests/test_gen_dict.py::test_individual_overrides - assert 'Factory' not in "{'a': ('', ... '_b': None}"`)

(ETA: the tests now pass, see comments)