### PR TITLE
Add Decimal support to json and pyyaml preconf converters

### DIFF
--- a/src/cattrs/preconf/json.py
+++ b/src/cattrs/preconf/json.py
@@ -3,6 +3,7 @@
 from base64 import b85decode, b85encode
 from collections.abc import Set
 from datetime import date, datetime
+from decimal import Decimal
 from json import dumps, loads
 from typing import Any, TypeVar, Union
 
@@ -32,6 +33,7 @@ def configure_converter(converter: BaseConverter) -> None:
 
     * bytes are serialized as base85 strings
     * datetimes are serialized as ISO 8601
+    * decimals are serialized as strings to preserve precision
     * counters are serialized as dicts
     * sets are serialized as lists
     * string and int enums are passed through when unstructuring
@@ -45,6 +47,8 @@ def configure_converter(converter: BaseConverter) -> None:
         bytes, lambda v: (b85encode(v) if v else b"").decode("utf8")
     )
     converter.register_structure_hook(bytes, lambda v, _: b85decode(v))
+    converter.register_unstructure_hook(Decimal, str)
+    converter.register_structure_hook(Decimal, lambda v, _: Decimal(v))
     converter.register_unstructure_hook(datetime, lambda v: v.isoformat())
     converter.register_structure_hook(datetime, lambda v, _: datetime.fromisoformat(v))
     converter.register_unstructure_hook(date, lambda v: v.isoformat())

--- a/src/cattrs/preconf/pyyaml.py
+++ b/src/cattrs/preconf/pyyaml.py
@@ -1,6 +1,7 @@
 """Preconfigured converters for pyyaml."""
 
 from datetime import date, datetime
+from decimal import Decimal
 from functools import partial
 from typing import Any, TypeVar, Union
 
@@ -38,6 +39,7 @@ def configure_converter(converter: BaseConverter) -> None:
     * frozensets are serialized as lists
     * string enums are converted into strings explicitly
     * datetimes and dates are validated
+    * decimals are serialized as strings to preserve precision
     * typed namedtuples are serialized as lists
 
     .. versionchanged:: 24.1.0
@@ -46,6 +48,8 @@ def configure_converter(converter: BaseConverter) -> None:
     converter.register_unstructure_hook(
         str, lambda v: v if v.__class__ is str else v.value
     )
+    converter.register_unstructure_hook(Decimal, str)
+    converter.register_structure_hook(Decimal, lambda v, _: Decimal(str(v)))
 
     # datetime inherits from date, so identity unstructure hook used
     # here to prevent the date unstructure hook running.

--- a/tests/test_preconf.py
+++ b/tests/test_preconf.py
@@ -1036,3 +1036,61 @@ def test_literal_dicts_msgspec():
 def test_literal_dicts_tomllib():
     """Dicts with keys that aren't subclasses of `type` work."""
     test_literal_dicts(tomllib_make_converter)
+
+
+@pytest.mark.parametrize(
+    "converter_factory",
+    [
+        json_make_converter,
+        pyyaml_make_converter,
+    ],
+)
+def test_decimal_round_trip(converter_factory: Callable[[], Converter]):
+    """decimal.Decimal fields are serialized as strings and round-trip correctly."""
+    from decimal import Decimal
+
+    @define
+    class Order:
+        amount: Decimal
+
+    converter = converter_factory()
+    order = Order(amount=Decimal("19.99"))
+
+    unstructured = converter.unstructure(order)
+    assert unstructured["amount"] == "19.99"
+    assert isinstance(unstructured["amount"], str)
+
+    restored = converter.structure(unstructured, Order)
+    assert restored == order
+    assert isinstance(restored.amount, Decimal)
+
+
+def test_decimal_precision_preserved_json():
+    """Decimal precision is preserved (not lost to float) in the json converter."""
+    from decimal import Decimal
+
+    @define
+    class Foo:
+        value: Decimal
+
+    converter = json_make_converter()
+    # This value cannot be represented exactly as a float
+    original = Foo(value=Decimal("0.1") + Decimal("0.2"))
+    restored = converter.structure(converter.unstructure(original), Foo)
+    assert restored.value == original.value
+
+
+def test_decimal_json_dumps_loads():
+    """decimal.Decimal works end-to-end with JsonConverter.dumps()/loads()."""
+    from decimal import Decimal
+
+    @define
+    class Invoice:
+        total: Decimal
+        tax: Decimal
+
+    converter = json_make_converter()
+    invoice = Invoice(total=Decimal("99.99"), tax=Decimal("8.50"))
+    s = converter.dumps(invoice)
+    restored = converter.loads(s, Invoice)
+    assert restored == invoice


### PR DESCRIPTION
Closes #761

## Summary

- Registers `Decimal` unstructure/structure hooks in `preconf/json.py` and `preconf/pyyaml.py`
- Decimals are serialized as strings to avoid the float precision loss that `json.dumps(float(Decimal("19.99")))` causes
- pyyaml hook uses `Decimal(str(v))` so that values YAML auto-parses as floats are still re-converted correctly
- Adds 3 new tests in `tests/test_preconf.py`: round-trip, precision preservation, and `dumps`/`loads` integration

## Behaviour

```python
from decimal import Decimal
from attrs import define
from cattrs.preconf.json import make_converter

@define
class Order:
    amount: Decimal

converter = make_converter()
order = Order(amount=Decimal("19.99"))

data = converter.unstructure(order)   # {"amount": "19.99"}  ← string, not float
assert data["amount"] == "19.99"

restored = converter.structure(data, Order)
assert restored == order              # exact Decimal equality
```

## Test plan

- [ ] `test_decimal_round_trip` — verifies string representation and round-trip equality for both json and pyyaml converters
- [ ] `test_decimal_precision_preserved_json` — `0.1 + 0.2` round-trips without float precision loss
- [ ] `test_decimal_json_dumps_loads` — end-to-end `dumps`/`loads` with multiple Decimal fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)