### PR TITLE
Disambiguate unions independent of member class order (#230)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,8 @@ Our backwards-compatibility policy can be found [here](https://github.com/python
 
 ## NEXT (UNRELEASED)
 
+- Fix `create_default_dis_func <cattrs.disambiguators.create_default_dis_func>` (aka `create_uniq_field_dis_func`) failing to disambiguate valid unions depending on the order of the member classes; unique fields are now resolved iteratively to a fixpoint.
+  ([#230](https://github.com/python-attrs/cattrs/issues/230) [#765](https://github.com/python-attrs/cattrs/pull/765))
 - Support more recursive types on 3.14+ with specialized factories for [`annotationlib.ForwardRef`](https://docs.python.org/3/library/annotationlib.html#annotationlib.ForwardRef).
   ([#740](https://github.com/python-attrs/cattrs/issues/740) [#741](https://github.com/python-attrs/cattrs/pull/741))
 - `Converter <cattrs.Converter>` now uses specialized hook factories to generate hooks for tuples, increasing speed.

--- a/src/cattrs/disambiguators.py
+++ b/src/cattrs/disambiguators.py
@@ -131,33 +131,47 @@ def create_default_dis_func(
 
     # We start from classes with the largest number of unique fields
     # so we can do easy picks first, making later picks easier.
-    cls_and_attrs.sort(key=lambda c_a: len(c_a[1]), reverse=True)
+    remaining = sorted(cls_and_attrs, key=lambda c_a: len(c_a[1]), reverse=True)
 
-    fallback = None  # If none match, try this.
+    # Iterate to a fixpoint. On each pass, pin every class that has a
+    # non-default field unique among the classes not yet pinned. Pinning a
+    # class removes its fields from consideration, which can make a previously
+    # ambiguous class uniquely identifiable, so we repeat until a pass pins
+    # nothing. A single pass in a fixed order would miss those later picks and
+    # fail to disambiguate valid unions depending on the class order.
+    made_progress = True
+    while made_progress:
+        made_progress = False
+        still_remaining = []
+        for entry in remaining:
+            cl, cl_reqs, back_map = entry
+            other_reqs = reduce(
+                or_, (c_a[1] for c_a in remaining if c_a[0] is not cl), set()
+            )
+            uniq = cl_reqs - other_reqs
 
-    for cl, cl_reqs, back_map in cls_and_attrs:
-        # We do not have to consider classes we've already processed, since
-        # they will have been eliminated by the match dictionary already.
-        other_classes = [
-            c_and_a
-            for c_and_a in cls_and_attrs
-            if c_and_a[0] is not cl and c_and_a[0] not in uniq_attrs_dict.values()
-        ]
-        other_reqs = reduce(or_, (c_a[1] for c_a in other_classes), set())
-        uniq = cl_reqs - other_reqs
+            # We want a unique attribute with no default.
+            cl_fields = fields_dict(get_origin(cl) or cl)
+            for maybe_renamed_attr_name in uniq:
+                orig_name = back_map[maybe_renamed_attr_name]
+                if cl_fields[orig_name].default in (NOTHING, MISSING):
+                    uniq_attrs_dict[maybe_renamed_attr_name] = cl
+                    made_progress = True
+                    break
+            else:
+                still_remaining.append(entry)
+        remaining = still_remaining
 
-        # We want a unique attribute with no default.
-        cl_fields = fields_dict(get_origin(cl) or cl)
-        for maybe_renamed_attr_name in uniq:
-            orig_name = back_map[maybe_renamed_attr_name]
-            if cl_fields[orig_name].default in (NOTHING, MISSING):
-                break
-        else:
-            if fallback is None:
-                fallback = cl
-                continue
-            raise TypeError(f"{cl} has no usable non-default attributes")
-        uniq_attrs_dict[maybe_renamed_attr_name] = cl
+    # A class we could not pin to a unique non-default field can only be the
+    # single fallback (tried when no unique key matches). More than one such
+    # class is a genuine ambiguity.
+    if len(remaining) > 1:
+        raise TypeError(
+            "Could not disambiguate between "
+            + ", ".join(repr(c_a[0]) for c_a in remaining)
+            + ": no unique non-default attributes"
+        )
+    fallback = remaining[0][0] if remaining else None
 
     if fallback is None:
 

--- a/tests/test_disambiguators.py
+++ b/tests/test_disambiguators.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from functools import partial
+from itertools import permutations
 from typing import Literal, Union
 
 import pytest
@@ -111,6 +112,39 @@ def test_edge_errors():
     with pytest.raises(ValueError):
         # The input should be a mapping
         fn([])
+
+
+def test_disambiguation_is_order_independent():
+    """A valid union disambiguates regardless of the order of its members.
+
+    Regression test for #230: a class whose fields were all shared with another,
+    not-yet-pinned class was forced into the single fallback slot, so some
+    member orderings raised ``TypeError`` even though a valid assignment exists.
+    Here A is identified by ``a``, B by ``ab`` (once A is pinned), and C by
+    ``bc`` (once B is pinned); a single fixed-order pass misses those later
+    picks for half of the orderings.
+    """
+    c = Converter()
+
+    @define
+    class A:
+        ab: int
+        a: str
+
+    @define
+    class B:
+        ab: int
+        bc: int
+
+    @define
+    class C:
+        bc: int
+
+    for ordering in permutations((A, B, C)):
+        fn = create_default_dis_func(c, *ordering)
+        assert fn(asdict(A(1, "x"))) is A
+        assert fn(asdict(B(1, 2))) is B
+        assert fn(asdict(C(1))) is C
 
 
 def test_input_not_mapping():


### PR DESCRIPTION
Fixes #230.

### Problem

`create_default_dis_func` (aka `create_uniq_field_dis_func`) fails to disambiguate a valid union depending on the order its member classes are passed in.

```python
from attrs import define
from cattrs import Converter
from cattrs.disambiguators import create_default_dis_func

@define
class A: ab: int; a: str
@define
class B: ab: int; bc: int
@define
class C: bc: int

c = Converter()
create_default_dis_func(c, A, B, C)   # ok
create_default_dis_func(c, B, A, C)   # TypeError: <class 'C'> has no usable non-default attributes
```

A valid assignment exists (`A` -> `a`, `B` -> `ab`, `C` -> `bc`), and 3 of the 6 orderings find it while the other 3 raise.

### Root cause

The "unique keys" branch resolves discriminator fields in a single fixed-order pass. For each class it subtracts the fields of every *not-yet-pinned* class and takes what's left as that class's unique fields. A class whose fields are all shared with another still-unpinned class therefore gets no unique field and is pushed into the single `fallback` slot; a second such class then raises. Since the processing order is fixed up front (sorted once by field count) and never re-selects which class to pin next, whether the valid assignment is found depends on the input order. In the example, if `C` is processed while `B` is still unpinned, `C`'s only field `bc` is shared with `B`, so `C` has no unique field even though pinning `B` on `ab` first would free `bc` for `C`.

### Fix

Resolve unique fields iteratively to a fixpoint. On each pass, pin every class that has a non-default field unique among the classes *not yet pinned*. Pinning a class removes its fields from consideration, which can make a previously ambiguous class uniquely identifiable, so passes repeat until one pins nothing. The single class that still cannot be pinned becomes the fallback; more than one remaining is a genuine ambiguity and still raises `TypeError`. This is order-independent and contained to the one function; the discriminator-literal path and both `dis_func` variants are unchanged.

The generated `dis_func` still checks keys in insertion (pin) order, and that stays correct: a class is pinned only on a field unique among the classes still unpinned on that pass, so its key cannot appear in the payload of any class pinned later or in the fallback, and an earlier-pinned class's key cannot appear in a later class's payload.

### Test

`test_disambiguation_is_order_independent` builds the union above and asserts that all 6 orderings both succeed and route each member's payload back to the correct class. It fails on the current code (3 of 6 orderings raise) and passes with this change. The existing `test_edge_errors` cases (no fields, shared single field, unhelpful discriminator, and the fallback cases) still pass, as do the union suites.
