### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/src/cattrs/_compat.py
+++ b/src/cattrs/_compat.py
@@ -320,7 +320,7 @@ def is_mutable_sequence(type: Any) -> bool:
 def is_sequence(type: Any) -> bool:
     """A predicate function for sequences.
 
-    Matches lists, sequences, mutable sequences, deques and homogenous
+    Matches lists, sequences, mutable sequences, deques and homogeneous
     tuples.
     """
     origin = getattr(type, "__origin__", None)

--- a/src/cattrs/cols.py
+++ b/src/cattrs/cols.py
@@ -157,7 +157,7 @@ def list_structure_factory(type: type, converter: BaseConverter) -> StructureHoo
 def homogenous_tuple_structure_factory(
     type: type, converter: BaseConverter
 ) -> StructureHook:
-    """A hook factory for homogenous (all elements the same, indeterminate length) tuples.
+    """A hook factory for homogeneous (all elements the same, indeterminate length) tuples.
 
     Converts any given iterable into a tuple.
     """
@@ -217,7 +217,7 @@ def namedtuple_structure_factory(
     cl: type[tuple], converter: BaseConverter
 ) -> StructureHook:
     """A hook factory for structuring namedtuples from iterables."""
-    # We delegate to the existing infrastructure for heterogenous tuples.
+    # We delegate to the existing infrastructure for heterogeneous tuples.
     hetero_tuple_type = tuple[tuple(cl.__annotations__.values())]
     base_hook = converter.get_structure_hook(hetero_tuple_type)
     return lambda v, _: cl(*base_hook(v, hetero_tuple_type))

--- a/src/cattrs/converters.py
+++ b/src/cattrs/converters.py
@@ -927,7 +927,7 @@ class BaseConverter:
             # Just a Tuple. (No generic information.)
             return tuple(obj)
         if has_ellipsis:
-            # We're dealing with a homogenous tuple, tuple[int, ...]
+            # We're dealing with a homogeneous tuple, tuple[int, ...]
             tup_type = tup_params[0]
             conv = self._structure_func.dispatch(tup_type)
             if self.detailed_validation:
@@ -952,7 +952,7 @@ class BaseConverter:
                 return tuple(res)
             return tuple(conv(e, tup_type) for e in obj)
 
-        # We're dealing with a heterogenous tuple.
+        # We're dealing with a heterogeneous tuple.
         exp_len = len(tup_params)
         if self.detailed_validation:
             errors = []
@@ -1128,7 +1128,7 @@ class Converter(BaseConverter):
             if FrozenSetSubscriptable not in co:
                 co[FrozenSetSubscriptable] = co[OriginAbstractSet]
 
-        # abc.MutableSet overrrides, if defined, apply to sets
+        # abc.MutableSet overrides, if defined, apply to sets
         if OriginMutableSet in co and set not in co:
             co[set] = co[OriginMutableSet]
 

--- a/src/cattrs/gen/__init__.py
+++ b/src/cattrs/gen/__init__.py
@@ -862,7 +862,7 @@ def make_hetero_tuple_structure_fn(
     detailed_validation: bool | Literal["from_converter"] = "from_converter",
     use_linecache: bool = True,
 ) -> HeteroTupleStructureFn:
-    """Generate a specialized structuring function for a heterogenous tuple.
+    """Generate a specialized structuring function for a heterogeneous tuple.
 
     ..  versionadded:: NEXT
     """
@@ -962,7 +962,7 @@ def make_hetero_tuple_unstructure_fn(
     unstructure_to: Any = None,
     type_args: tuple | None = None,
 ) -> HeteroTupleUnstructureFn:
-    """Generate a specialized unstructure function for a heterogenous tuple.
+    """Generate a specialized unstructure function for a heterogeneous tuple.
 
     :param type_args: If provided, override the type arguments.
     """

--- a/src/cattrs/strategies/_subclasses.py
+++ b/src/cattrs/strategies/_subclasses.py
@@ -56,7 +56,7 @@ def include_subclasses(
     :param cl: A base `attrs` or `dataclass` class.
     :param converter: The `Converter` on which this strategy is applied. Do note that
         the strategy does not work for a :class:`cattrs.BaseConverter`.
-    :param subclasses: A tuple of sublcasses whose ancestor is `cl`. If left as `None`,
+    :param subclasses: A tuple of subclasses whose ancestor is `cl`. If left as `None`,
         subclasses are detected using recursively the `__subclasses__` method of `cl`
         and its descendents.
     :param union_strategy: A callable of two arguments passed by position


### PR DESCRIPTION
Fix minor typos found by codespell in docstrings and inline comments across the source files:

- `homogenous` → `homogeneous` (in docstrings and comments in `cols.py`, `converters.py`, `_compat.py`)
- `heterogenous` → `heterogeneous` (in docstrings and comments in `cols.py`, `converters.py`, `gen/__init__.py`)
- `overrrides` → `overrides` (comment in `converters.py`)
- `sublcasses` → `subclasses` (docstring in `strategies/_subclasses.py`)

No functional changes - only comments and docstrings were updated. Public API names (e.g. `homogenous_tuple_structure_factory`) were intentionally left unchanged for backwards compatibility.